### PR TITLE
Update README to reflect provider release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,88 +1,149 @@
+# Terraform NSX-T Provider
 
+This is the repository for the Terraform NSX-T Provider, which one can use with
+Terraform to work with [VMware NSX-T][vmware-nsxt].
 
-# terraform-provider-nsxt
-This repository contains the NSX Terraform provider for VMware NSX.
+[vmware-nsxt]: https://www.vmware.com/products/nsx.html
 
-NSX is the VMware network and security virtualization platform. More more information on the NSX product, please visit the [NSX Product Page](https://www.vmware.com/products/nsx.html)
+For general information about Terraform, visit the [official
+website][tf-website] and the [GitHub project page][tf-github].
 
-Documentation on the NSX platform can be found on the [NSX Documentation page](https://docs.vmware.com/en/VMware-NSX-T/index.html)
+[tf-website]: https://terraform.io/
+[tf-github]: https://github.com/hashicorp/terraform
 
-# Overview
+This provider plugin is maintained by a collaboration between
+[VMware](https://www.vmware.com/) and the Terraform team at
+[HashiCorp](https://www.hashicorp.com/).
 
-Supported data sources:
+# Using the Provider
 
-* edge_cluster
-* logical_tier0_router
-* ns_service
-* switching_profile
-* transport_zone
+The current version of this provider requires Terraform v0.10.2 or higher to
+run.
 
-Supported resources:
+Note that you need to run `terraform init` to fetch the provider before
+deploying. Read about the provider split and other changes to TF v0.10.0 in the
+official release announcement found [here][tf-0.10-announce].
 
-* alg_type_ns_service
-* dhcp_relay_profile
-* dhcp_relay_service
-* ether_type_ns_service
-* firewall_section
-* icmp_type_ns_service
-* igmp_type_ns_service
-* ip_protocol_ns_service
-* ip_set
-* l4_port_set_ns_service
-* logical_port
-* logical_router_downlink_port
-* logical_router_link_port_on_tier0
-* logical_router_link_port_on_tier1
-* logical_switch
-* logical_tier1_router
-* nat_rule
-* ns_group
-* static_route
+[tf-0.10-announce]: https://www.hashicorp.com/blog/hashicorp-terraform-0-10/
 
-# Interoperability
+## Full Provider Documentation
 
-The following versions of NSX are supported:
+The provider is documented in full on the Terraform website and can be found
+[here][tf-nsxt-docs]. Check the provider documentation for details on entering
+your connection information and how to get started with writing configuration
+for vSphere resources.
 
-- NSX-T 2.1.*
+[tf-nsxt-docs]: https://www.terraform.io/docs/providers/nsxt/index.html
 
-# Prerequisites
+### Controlling the provider version
 
-The following are prerequisites that need to be installed in order to run the NSX Terraform provider:
+Note that you can also control the provider version. This requires the use of a
+`provider` block in your Terraform configuration if you have not added one
+already.
 
-- Go 1.9.x onwards - [Go installation instructions](https://golang.org/doc/install)
+The syntax is as follows:
 
-- Terraform 0.10.x - [Terraform installation instructions](https://www.terraform.io/intro/getting-started/install.html)
+```hcl
+provider "nsxt" {
+  version = "~> 1.0"
+  ...
+}
+```
 
-Make sure that both Terraform and Go are in your path so they can be executed. To check versions of each you can run the following:
+Version locking uses a pessimistic operator, so this version lock would mean
+anything within the 1.x namespace, including or after 1.0.0. [Read
+more][provider-vc] on provider version control.
 
-    go version
+[provider-vc]: https://www.terraform.io/docs/configuration/providers.html#provider-versions
 
-    terraform version  
+# Building The Provider
 
-Make sure you have the following directory:
+**NOTE:** Unless you are [developing](#developing-the-provider) or require a
+pre-release bugfix or feature, you will want to use the officially released
+version of the provider (see [the section above](#using-the-provider)).
 
-    ~/.terraform.d/plugins/
+## Cloning the Project
 
-# Installation
+First, you will want to clone the repository to
+`$GOPATH/src/github.com/terraform-providers/terraform-provider-nsxt`:
 
-These commands will allow you to install the NSX Terraform provider:
+```sh
+mkdir -p $GOPATH/src/github.com/terraform-providers
+cd $GOPATH/src/github.com/terraform-providers
+git clone git@github.com:terraform-providers/terraform-provider-nsxt
+```
 
-    go get github.com/vmware/terraform-provider-nsxt
+## Running the Build
 
-    cd $GOROOT/src/github.com/vmware/terraform-provider-nsxt
+After the clone has been completed, you can enter the provider directory and
+build the provider.
 
-    go build -o ~/.terraform.d/plugins/terraform-provider-nsxt
+```sh
+cd $GOPATH/src/github.com/terraform-providers/terraform-provider-nsxt
+make build
+```
 
-# Contributing
+## Installing the Local Plugin
 
-The terraform-provider-nsxt project team welcomes contributions from the community. If you wish to contribute code and you have not signed our contributor license agreement (CLA), our bot will update the issue when you open a Pull Request. For any questions about the CLA process, please refer to our [FAQ](https://cla.vmware.com/faq). For more detailed information, refer to [CONTRIBUTING](https://github.com/vmware/terraform-provider-nsxt/blob/master/CONTRIBUTING.md).
+After the build is complete, copy the `terraform-provider-nsxt` binary into
+the same path as your `terraform` binary, and re-run `terraform init`.
 
-# Support
+After this, your project-local `.terraform/plugins/ARCH/lock.json` (where `ARCH`
+matches the architecture of your machine) file should contain a SHA256 sum that
+matches the local plugin. Run `shasum -a 256` on the binary to verify the values
+match.
 
-The NSX Terraform provider is community supported. For bugs and feature requests please open a Github Issue and label it appropriately. As this is a community supported solution there is no SLA for resolutions.
+# Developing the Provider
 
-# License
+**NOTE:** Before you start work on a feature, please make sure to check the
+[issue tracker][gh-issues] and existing [pull requests][gh-prs] to ensure that
+work is not being duplicated. For further clarification, you can also ask in a
+new issue.
 
-Copyright © 2015-2018 VMware, Inc. All Rights Reserved.
+[gh-issues]: https://github.com/terraform-providers/terraform-provider-nsxt/issues
+[gh-prs]: https://github.com/terraform-providers/terraform-provider-nsxt/pulls
 
-The NSX Terraform provider is available under [MPL2.0 license](https://github.com/vmware/terraform-provider-nsxt/blob/master/LICENSE.txt).
+If you wish to work on the provider, you'll first need [Go][go-website]
+installed on your machine (version 1.9+ is **required**). You'll also need to
+correctly setup a [GOPATH][gopath], as well as adding `$GOPATH/bin` to your
+`$PATH`.
+
+[go-website]: https://golang.org/
+[gopath]: http://golang.org/doc/code.html#GOPATH
+
+See [Building the Provider](#building-the-provider) for details on building the
+provider.
+
+# Testing the Provider
+
+**NOTE:** Testing the NSX-T provider is currently a complex operation as it
+requires having a NSX-T manager endpoint to test against, which should be
+hosting a standard configuration for a NSX-T cluster.
+
+## Configuring Environment Variables
+
+Most of the tests in this provider require a comprehensive list of environment
+variables to run. See the individual `*_test.go` files in the [`nsxt/`](nsxt/)
+directory for more details, in addition to
+[`tests_utils.go`](nsxt/tests_utils.go) for details on some tunables that can be
+used to specify the locations of certain pre-created resources that some tests
+require.
+
+## Running the Acceptance Tests
+
+After this is done, you can run the acceptance tests by running:
+
+```sh
+$ make testacc
+```
+
+If you want to run against a specific set of tests, run `make testacc` with the
+`TESTARGS` parameter containing the run mask as per below:
+
+```sh
+make testacc TESTARGS="-run=TestAccResourceNsxtLogicalSwitch"
+```
+
+This following example would run all of the acceptance tests matching
+`TestAccResourceNsxtLogicalSwitch`. Change this for the specific tests you want
+to run.


### PR DESCRIPTION
Now that the provider has been released, there are a number of items in
the old README that are no longer relevant. This commit replaces the
README with one that has been template from the vSphere provider, and
should better reflect what one would need to do to use the provider or
develop it, including up to date installation and development
instructions, and a referral to the Terraform website for documentation.

CC @avoltmer. Fixes #1.
