### PR TITLE
Check schema set err for complex types

### DIFF
--- a/nsxt/resource_nsxt_logical_port.go
+++ b/nsxt/resource_nsxt_logical_port.go
@@ -102,7 +102,10 @@ func resourceNsxtLogicalPortRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("description", logicalPort.Description)
 	d.Set("logical_switch_id", logicalPort.LogicalSwitchId)
 	d.Set("admin_state", logicalPort.AdminState)
-	setSwitchingProfileIdsInSchema(d, nsxClient, logicalPort.SwitchingProfileIds)
+	err = setSwitchingProfileIdsInSchema(d, nsxClient, logicalPort.SwitchingProfileIds)
+	if err != nil {
+		return fmt.Errorf("Error during logical port switching profiles set in schema: %v", err)
+	}
 	setTagsInSchema(d, logicalPort.Tags)
 
 	return nil

--- a/nsxt/resource_nsxt_logical_router_downlink_port.go
+++ b/nsxt/resource_nsxt_logical_router_downlink_port.go
@@ -161,7 +161,10 @@ func resourceNsxtLogicalRouterDownLinkPortRead(d *schema.ResourceData, m interfa
 	d.Set("linked_logical_switch_port_id", logicalRouterDownLinkPort.LinkedLogicalSwitchPortId.TargetId)
 	setIPSubnetsInSchema(d, logicalRouterDownLinkPort.Subnets)
 	d.Set("urpf_mode", logicalRouterDownLinkPort.UrpfMode)
-	setServiceBindingsInSchema(d, logicalRouterDownLinkPort.ServiceBindings, "service_binding")
+	err = setServiceBindingsInSchema(d, logicalRouterDownLinkPort.ServiceBindings, "service_binding")
+	if err != nil {
+		return fmt.Errorf("Error during LogicalRouterDownLinkPort service_binding set in schema: %v", err)
+	}
 
 	return nil
 }

--- a/nsxt/resource_nsxt_logical_router_link_port_on_tier0.go
+++ b/nsxt/resource_nsxt_logical_router_link_port_on_tier0.go
@@ -105,7 +105,10 @@ func resourceNsxtLogicalRouterLinkPortOnTier0Read(d *schema.ResourceData, m inte
 	setTagsInSchema(d, logicalRouterLinkPort.Tags)
 	d.Set("logical_router_id", logicalRouterLinkPort.LogicalRouterId)
 	d.Set("linked_logical_router_port_id", logicalRouterLinkPort.LinkedLogicalRouterPortId)
-	setServiceBindingsInSchema(d, logicalRouterLinkPort.ServiceBindings, "service_binding")
+	err = setServiceBindingsInSchema(d, logicalRouterLinkPort.ServiceBindings, "service_binding")
+	if err != nil {
+		return fmt.Errorf("Error during LogicalRouterLinkPortOnTier0 service_binding set in schema: %v", err)
+	}
 
 	return nil
 }

--- a/nsxt/resource_nsxt_logical_router_link_port_on_tier1.go
+++ b/nsxt/resource_nsxt_logical_router_link_port_on_tier1.go
@@ -107,7 +107,10 @@ func resourceNsxtLogicalRouterLinkPortOnTier1Read(d *schema.ResourceData, m inte
 	setTagsInSchema(d, logicalRouterLinkPort.Tags)
 	d.Set("logical_router_id", logicalRouterLinkPort.LogicalRouterId)
 	d.Set("linked_logical_router_port_id", logicalRouterLinkPort.LinkedLogicalRouterPortId.TargetId)
-	setServiceBindingsInSchema(d, logicalRouterLinkPort.ServiceBindings, "service_binding")
+	err = setServiceBindingsInSchema(d, logicalRouterLinkPort.ServiceBindings, "service_binding")
+	if err != nil {
+		return fmt.Errorf("Error during LogicalRouterLinkPortOnTier1 service_binding set in schema: %v", err)
+	}
 
 	return nil
 }

--- a/nsxt/resource_nsxt_logical_switch.go
+++ b/nsxt/resource_nsxt_logical_switch.go
@@ -198,12 +198,18 @@ func resourceNsxtLogicalSwitchRead(d *schema.ResourceData, m interface{}) error 
 	d.Set("description", logicalSwitch.Description)
 	d.Set("display_name", logicalSwitch.DisplayName)
 	setTagsInSchema(d, logicalSwitch.Tags)
-	setAddressBindingsInSchema(d, logicalSwitch.AddressBindings)
+	err = setAddressBindingsInSchema(d, logicalSwitch.AddressBindings)
+	if err != nil {
+		return fmt.Errorf("Error during logical switch address bindings set in schema: %v", err)
+	}
 	d.Set("admin_state", logicalSwitch.AdminState)
 	d.Set("ip_pool_id", logicalSwitch.IpPoolId)
 	d.Set("mac_pool_id", logicalSwitch.MacPoolId)
 	d.Set("replication_mode", logicalSwitch.ReplicationMode)
-	setSwitchingProfileIdsInSchema(d, nsxClient, logicalSwitch.SwitchingProfileIds)
+	err = setSwitchingProfileIdsInSchema(d, nsxClient, logicalSwitch.SwitchingProfileIds)
+	if err != nil {
+		return fmt.Errorf("Error during logical switch profiles set in schema: %v", err)
+	}
 	d.Set("transport_zone_id", logicalSwitch.TransportZoneId)
 	d.Set("vlan", logicalSwitch.Vlan)
 	d.Set("vni", logicalSwitch.Vni)

--- a/nsxt/resource_nsxt_logical_tier1_router.go
+++ b/nsxt/resource_nsxt_logical_tier1_router.go
@@ -215,7 +215,10 @@ func resourceNsxtLogicalTier1RouterRead(d *schema.ResourceData, m interface{}) e
 	d.Set("advanced_config", logicalRouter.AdvancedConfig)
 	d.Set("edge_cluster_id", logicalRouter.EdgeClusterId)
 	d.Set("failover_mode", logicalRouter.FailoverMode)
-	setResourceReferencesInSchema(d, logicalRouter.FirewallSections, "firewall_sections")
+	err = setResourceReferencesInSchema(d, logicalRouter.FirewallSections, "firewall_sections")
+	if err != nil {
+		return fmt.Errorf("Error during LogicalTier1Router firewall sections set in schema: %v", err)
+	}
 	d.Set("preferred_edge_cluster_member_index", logicalRouter.PreferredEdgeClusterMemberIndex)
 	d.Set("router_type", logicalRouter.RouterType)
 

--- a/nsxt/resource_nsxt_ns_group.go
+++ b/nsxt/resource_nsxt_ns_group.go
@@ -114,7 +114,7 @@ func getMembershipCriteriaFromSchema(d *schema.ResourceData) []manager.NsGroupTa
 	return expresionList
 }
 
-func setMembershipCriteriaInSchema(d *schema.ResourceData, membershipCriterias []manager.NsGroupTagExpression) {
+func setMembershipCriteriaInSchema(d *schema.ResourceData, membershipCriterias []manager.NsGroupTagExpression) error {
 	var expresionList []map[string]interface{}
 	for _, criteria := range membershipCriterias {
 		elem := make(map[string]interface{})
@@ -125,7 +125,8 @@ func setMembershipCriteriaInSchema(d *schema.ResourceData, membershipCriterias [
 		elem["target_type"] = criteria.TargetType
 		expresionList = append(expresionList, elem)
 	}
-	d.Set("membership_criteria", expresionList)
+	err := d.Set("membership_criteria", expresionList)
+	return err
 }
 
 func getMembersFromSchema(d *schema.ResourceData) []manager.NsGroupSimpleExpression {
@@ -145,7 +146,7 @@ func getMembersFromSchema(d *schema.ResourceData) []manager.NsGroupSimpleExpress
 	return expresionList
 }
 
-func setMembersInSchema(d *schema.ResourceData, members []manager.NsGroupSimpleExpression) {
+func setMembersInSchema(d *schema.ResourceData, members []manager.NsGroupSimpleExpression) error {
 	var expresionList []map[string]interface{}
 	for _, member := range members {
 		elem := make(map[string]interface{})
@@ -153,7 +154,8 @@ func setMembersInSchema(d *schema.ResourceData, members []manager.NsGroupSimpleE
 		elem["value"] = member.Value
 		expresionList = append(expresionList, elem)
 	}
-	d.Set("member", expresionList)
+	err := d.Set("member", expresionList)
+	return err
 }
 
 func resourceNsxtNsGroupCreate(d *schema.ResourceData, m interface{}) error {
@@ -208,8 +210,12 @@ func resourceNsxtNsGroupRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("description", nsGroup.Description)
 	d.Set("display_name", nsGroup.DisplayName)
 	setTagsInSchema(d, nsGroup.Tags)
-	setMembersInSchema(d, nsGroup.Members)
-	setMembershipCriteriaInSchema(d, nsGroup.MembershipCriteria)
+	err1 := setMembersInSchema(d, nsGroup.Members)
+
+	err2 := setMembershipCriteriaInSchema(d, nsGroup.MembershipCriteria)
+	if err1 != nil || err2 != nil {
+		return fmt.Errorf("Error during NsGroup set in schema: %v / %v", err1, err2)
+	}
 
 	return nil
 }

--- a/nsxt/resource_nsxt_static_route.go
+++ b/nsxt/resource_nsxt_static_route.go
@@ -117,7 +117,7 @@ func getNextHopsFromSchema(d *schema.ResourceData) []manager.StaticRouteNextHop 
 	return nextHopsList
 }
 
-func setNextHopsInSchema(d *schema.ResourceData, nextHops []manager.StaticRouteNextHop) {
+func setNextHopsInSchema(d *schema.ResourceData, nextHops []manager.StaticRouteNextHop) error {
 	var nextHopsList []map[string]interface{}
 	for _, staticRouteNextHop := range nextHops {
 		elem := make(map[string]interface{})
@@ -130,7 +130,8 @@ func setNextHopsInSchema(d *schema.ResourceData, nextHops []manager.StaticRouteN
 		}
 		nextHopsList = append(nextHopsList, elem)
 	}
-	d.Set("next_hop", nextHopsList)
+	err := d.Set("next_hop", nextHopsList)
+	return err
 }
 
 func resourceNsxtStaticRouteCreate(d *schema.ResourceData, m interface{}) error {
@@ -196,7 +197,10 @@ func resourceNsxtStaticRouteRead(d *schema.ResourceData, m interface{}) error {
 	setTagsInSchema(d, staticRoute.Tags)
 	d.Set("logical_router_id", staticRoute.LogicalRouterId)
 	d.Set("network", staticRoute.Network)
-	setNextHopsInSchema(d, staticRoute.NextHops)
+	err = setNextHopsInSchema(d, staticRoute.NextHops)
+	if err != nil {
+		return fmt.Errorf("Error during StaticRoute set in schema: %v", err)
+	}
 
 	return nil
 }

--- a/nsxt/utils.go
+++ b/nsxt/utils.go
@@ -82,7 +82,7 @@ func getTagsFromSchema(d *schema.ResourceData) []common.Tag {
 	return tagList
 }
 
-func setTagsInSchema(d *schema.ResourceData, tags []common.Tag) {
+func setTagsInSchema(d *schema.ResourceData, tags []common.Tag) error {
 	var tagList []map[string]string
 	for _, tag := range tags {
 		elem := make(map[string]string)
@@ -90,7 +90,8 @@ func setTagsInSchema(d *schema.ResourceData, tags []common.Tag) {
 		elem["tag"] = tag.Tag
 		tagList = append(tagList, elem)
 	}
-	d.Set("tag", tagList)
+	err := d.Set("tag", tagList)
+	return err
 }
 
 // utilities to define & handle switching profiles
@@ -131,7 +132,7 @@ func getSwitchingProfileIdsFromSchema(d *schema.ResourceData) []manager.Switchin
 	return profileList
 }
 
-func setSwitchingProfileIdsInSchema(d *schema.ResourceData, nsxClient *nsxt.APIClient, profiles []manager.SwitchingProfileTypeIdEntry) {
+func setSwitchingProfileIdsInSchema(d *schema.ResourceData, nsxClient *nsxt.APIClient, profiles []manager.SwitchingProfileTypeIdEntry) error {
 	var profileList []map[string]string
 	for _, profile := range profiles {
 		// ignore system owned profiles
@@ -145,7 +146,8 @@ func setSwitchingProfileIdsInSchema(d *schema.ResourceData, nsxClient *nsxt.APIC
 		elem["value"] = profile.Value
 		profileList = append(profileList, elem)
 	}
-	d.Set("switching_profile_id", profileList)
+	err := d.Set("switching_profile_id", profileList)
+	return err
 }
 
 // utilities to define & handle address bindings
@@ -193,7 +195,7 @@ func getAddressBindingsFromSchema(d *schema.ResourceData) []manager.PacketAddres
 	return bindingList
 }
 
-func setAddressBindingsInSchema(d *schema.ResourceData, bindings []manager.PacketAddressClassifier) {
+func setAddressBindingsInSchema(d *schema.ResourceData, bindings []manager.PacketAddressClassifier) error {
 	var bindingList []map[string]interface{}
 	for _, binding := range bindings {
 		elem := make(map[string]interface{})
@@ -202,7 +204,8 @@ func setAddressBindingsInSchema(d *schema.ResourceData, bindings []manager.Packe
 		elem["vlan"] = binding.Vlan
 		bindingList = append(bindingList, elem)
 	}
-	d.Set("address_binding", bindingList)
+	err := d.Set("address_binding", bindingList)
+	return err
 }
 
 func getResourceReferencesSchema(required bool, computed bool, validTargetTypes []string, description string) *schema.Schema {
@@ -292,9 +295,10 @@ func returnResourceReferences(references []common.ResourceReference) []map[strin
 	return referenceList
 }
 
-func setResourceReferencesInSchema(d *schema.ResourceData, references []common.ResourceReference, schemaAttrName string) {
+func setResourceReferencesInSchema(d *schema.ResourceData, references []common.ResourceReference, schemaAttrName string) error {
 	referenceList := returnResourceReferences(references)
-	d.Set(schemaAttrName, referenceList)
+	err := d.Set(schemaAttrName, referenceList)
+	return err
 }
 
 func getServiceBindingsFromSchema(d *schema.ResourceData, schemaAttrName string) []manager.ServiceBinding {
@@ -314,7 +318,7 @@ func getServiceBindingsFromSchema(d *schema.ResourceData, schemaAttrName string)
 	return bindingList
 }
 
-func setServiceBindingsInSchema(d *schema.ResourceData, serviceBindings []manager.ServiceBinding, schemaAttrName string) {
+func setServiceBindingsInSchema(d *schema.ResourceData, serviceBindings []manager.ServiceBinding, schemaAttrName string) error {
 	var referenceList []map[string]interface{}
 	for _, binding := range serviceBindings {
 		elem := make(map[string]interface{})
@@ -324,7 +328,8 @@ func setServiceBindingsInSchema(d *schema.ResourceData, serviceBindings []manage
 		elem["target_type"] = binding.ServiceId.TargetType
 		referenceList = append(referenceList, elem)
 	}
-	d.Set(schemaAttrName, referenceList)
+	err := d.Set(schemaAttrName, referenceList)
+	return err
 }
 
 func getAdminStateSchema() *schema.Schema {


### PR DESCRIPTION
The schema set command can fail some times.
Adding the validation on the returned error helps debugging
the problem.