### PR TITLE
Fix destruction test in unittests

### DIFF
--- a/nsxt/resource_nsxt_dhcp_relay_profile_test.go
+++ b/nsxt/resource_nsxt_dhcp_relay_profile_test.go
@@ -104,7 +104,7 @@ func testAccNSXDhcpRelayProfileCheckDestroy(state *terraform.State, displayName 
 	nsxClient := testAccProvider.Meta().(*nsxt.APIClient)
 	for _, rs := range state.RootModule().Resources {
 
-		if rs.Type != "nsxt_logical_port" {
+		if rs.Type != "nsxt_dhcp_relay_profile" {
 			continue
 		}
 

--- a/nsxt/resource_nsxt_dhcp_relay_service_test.go
+++ b/nsxt/resource_nsxt_dhcp_relay_service_test.go
@@ -104,7 +104,7 @@ func testAccNSXDhcpRelayServiceCheckDestroy(state *terraform.State, displayName 
 	nsxClient := testAccProvider.Meta().(*nsxt.APIClient)
 	for _, rs := range state.RootModule().Resources {
 
-		if rs.Type != "nsxt_logical_port" {
+		if rs.Type != "nsxt_dhcp_relay_service" {
 			continue
 		}
 

--- a/nsxt/resource_nsxt_firewall_section_test.go
+++ b/nsxt/resource_nsxt_firewall_section_test.go
@@ -360,7 +360,7 @@ func testAccNSXFirewallSectionCheckDestroy(state *terraform.State, displayName s
 
 	for _, rs := range state.RootModule().Resources {
 
-		if rs.Type != "nsxt_logical_port" {
+		if rs.Type != "nsxt_firewall_section" {
 			continue
 		}
 

--- a/nsxt/resource_nsxt_ip_set_test.go
+++ b/nsxt/resource_nsxt_ip_set_test.go
@@ -142,7 +142,7 @@ func testAccNSXIpSetCheckDestroy(state *terraform.State, displayName string) err
 	nsxClient := testAccProvider.Meta().(*nsxt.APIClient)
 	for _, rs := range state.RootModule().Resources {
 
-		if rs.Type != "nsxt_logical_port" {
+		if rs.Type != "nsxt_ip_set" {
 			continue
 		}
 

--- a/nsxt/resource_nsxt_ns_group_test.go
+++ b/nsxt/resource_nsxt_ns_group_test.go
@@ -201,7 +201,7 @@ func testAccNSXNSGroupCheckDestroy(state *terraform.State, displayName string) e
 	nsxClient := testAccProvider.Meta().(*nsxt.APIClient)
 	for _, rs := range state.RootModule().Resources {
 
-		if rs.Type != "nsxt_logical_port" {
+		if rs.Type != "nsxt_ns_group" {
 			continue
 		}
 


### PR DESCRIPTION
There was a copy/paste bug in some unittests which caused the destruction
tests to be skipped.