### PR TITLE
Adding Logical DHCP port resource

### DIFF
--- a/nsxt/provider.go
+++ b/nsxt/provider.go
@@ -95,6 +95,7 @@ func Provider() terraform.ResourceProvider {
 			"nsxt_dhcp_server_profile":               resourceNsxtDhcpServerProfile(),
 			"nsxt_logical_dhcp_server":               resourceNsxtLogicalDhcpServer(),
 			"nsxt_logical_switch":                    resourceNsxtLogicalSwitch(),
+			"nsxt_logical_dhcp_port":                 resourceNsxtLogicalDhcpPort(),
 			"nsxt_logical_port":                      resourceNsxtLogicalPort(),
 			"nsxt_logical_tier0_router":              resourceNsxtLogicalTier0Router(),
 			"nsxt_logical_tier1_router":              resourceNsxtLogicalTier1Router(),

--- a/nsxt/resource_nsxt_logical_dhcp_port.go
+++ b/nsxt/resource_nsxt_logical_dhcp_port.go
@@ -1,0 +1,184 @@
+/* Copyright © 2017 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/schema"
+	api "github.com/vmware/go-vmware-nsxt"
+	"github.com/vmware/go-vmware-nsxt/manager"
+	"log"
+	"net/http"
+)
+
+var dhcpType = "DHCP_SERVICE"
+
+func resourceNsxtLogicalDhcpPort() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceNsxtLogicalDhcpPortCreate,
+		Read:   resourceNsxtLogicalDhcpPortRead,
+		Update: resourceNsxtLogicalDhcpPortUpdate,
+		Delete: resourceNsxtLogicalDhcpPortDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"revision": getRevisionSchema(),
+			"display_name": &schema.Schema{
+				Type:        schema.TypeString,
+				Description: "The display name of this resource. Defaults to ID if not set",
+				Optional:    true,
+				Computed:    true,
+			},
+			"description": &schema.Schema{
+				Type:        schema.TypeString,
+				Description: "Description of this resource",
+				Optional:    true,
+			},
+			"logical_switch_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Description: "Id of the Logical switch that this port belongs to",
+				Required:    true,
+				ForceNew:    true, // Cannot change the logical switch of a logical port
+			},
+			"dhcp_server_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Description: "Id of the Logical DHCP server this port belongs to",
+				Required:    true,
+			},
+			"admin_state": getAdminStateSchema(),
+			//TODO(asarfaty): switching profiles for DHCP ports are currently ignored by NSX
+			//"switching_profile_id": getSwitchingProfileIdsSchema(),
+			"tag": getTagsSchema(),
+		},
+	}
+}
+
+func resourceNsxtLogicalDhcpPortCreate(d *schema.ResourceData, m interface{}) error {
+	nsxClient := m.(*api.APIClient)
+	name := d.Get("display_name").(string)
+	description := d.Get("description").(string)
+	lsID := d.Get("logical_switch_id").(string)
+	adminState := d.Get("admin_state").(string)
+	//profilesList := getSwitchingProfileIdsFromSchema(d)
+	tagList := getTagsFromSchema(d)
+	dhcpServerId := d.Get("dhcp_server_id").(string)
+	attachment := manager.LogicalPortAttachment{
+		AttachmentType: dhcpType,
+		Id:             dhcpServerId,
+	}
+	lp := manager.LogicalPort{
+		DisplayName:     name,
+		Description:     description,
+		LogicalSwitchId: lsID,
+		AdminState:      adminState,
+		//SwitchingProfileIds: profilesList,
+		Tags:       tagList,
+		Attachment: &attachment,
+	}
+
+	lp, resp, err := nsxClient.LogicalSwitchingApi.CreateLogicalPort(nsxClient.Context, lp)
+
+	if err != nil {
+		return fmt.Errorf("Error while creating logical DHCP port %s: %v", name, err)
+	}
+	if resp.StatusCode != http.StatusCreated {
+		return fmt.Errorf("Unexpected status returned during Logical DHCP port create: %v", resp.StatusCode)
+	}
+
+	resourceID := lp.Id
+	d.SetId(resourceID)
+
+	return resourceNsxtLogicalDhcpPortRead(d, m)
+}
+
+func resourceNsxtLogicalDhcpPortRead(d *schema.ResourceData, m interface{}) error {
+	nsxClient := m.(*api.APIClient)
+	id := d.Id()
+	if id == "" {
+		return fmt.Errorf("Error obtaining logical DHCP port ID from state during read")
+	}
+	LogicalDhcpPort, resp, err := nsxClient.LogicalSwitchingApi.GetLogicalPort(nsxClient.Context, id)
+
+	if resp.StatusCode == http.StatusNotFound {
+		d.SetId("")
+		log.Printf("[DEBUG] Logical DHCP port %s not found", id)
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error while reading logical DHCP port %s: %v", id, err)
+	}
+	if LogicalDhcpPort.Attachment == nil || LogicalDhcpPort.Attachment.AttachmentType != dhcpType {
+		return fmt.Errorf("Error reading DHCP port %s: This not a DHCP port", id)
+	}
+
+	d.Set("revision", LogicalDhcpPort.Revision)
+	d.Set("display_name", LogicalDhcpPort.DisplayName)
+	d.Set("description", LogicalDhcpPort.Description)
+	d.Set("logical_switch_id", LogicalDhcpPort.LogicalSwitchId)
+	d.Set("admin_state", LogicalDhcpPort.AdminState)
+	d.Set("dhcp_server_id", LogicalDhcpPort.Attachment.Id)
+	//err = setSwitchingProfileIdsInSchema(d, nsxClient, LogicalDhcpPort.SwitchingProfileIds)
+	//if err != nil {
+	//	return fmt.Errorf("Error during logical DHCP port switching profiles set in schema: %v", err)
+	//}
+	setTagsInSchema(d, LogicalDhcpPort.Tags)
+
+	return nil
+}
+
+func resourceNsxtLogicalDhcpPortUpdate(d *schema.ResourceData, m interface{}) error {
+	nsxClient := m.(*api.APIClient)
+	id := d.Id()
+	name := d.Get("display_name").(string)
+	description := d.Get("description").(string)
+	adminState := d.Get("admin_state").(string)
+	lsID := d.Get("logical_switch_id").(string)
+	//profilesList := getSwitchingProfileIdsFromSchema(d)
+	tagList := getTagsFromSchema(d)
+	revision := int64(d.Get("revision").(int))
+	dhcpServerId := d.Get("dhcp_server_id").(string)
+	attachment := manager.LogicalPortAttachment{
+		AttachmentType: "DHCP_SERVICE",
+		Id:             dhcpServerId,
+	}
+	lp := manager.LogicalPort{
+		Revision:        revision,
+		DisplayName:     name,
+		Description:     description,
+		LogicalSwitchId: lsID,
+		AdminState:      adminState,
+		//SwitchingProfileIds: profilesList,
+		Tags:       tagList,
+		Attachment: &attachment,
+	}
+
+	lp, resp, err := nsxClient.LogicalSwitchingApi.UpdateLogicalPort(nsxClient.Context, id, lp)
+	if err != nil || resp.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("Error while updating logical DHCP port %s: %v", id, err)
+	}
+	return resourceNsxtLogicalDhcpPortRead(d, m)
+}
+
+func resourceNsxtLogicalDhcpPortDelete(d *schema.ResourceData, m interface{}) error {
+	nsxClient := m.(*api.APIClient)
+	lpID := d.Id()
+	if lpID == "" {
+		return fmt.Errorf("Error obtaining logical DHCP port ID from state during delete")
+	}
+	localVarOptionals := make(map[string]interface{})
+	localVarOptionals["detach"] = true
+	resp, err := nsxClient.LogicalSwitchingApi.DeleteLogicalPort(nsxClient.Context, lpID, localVarOptionals)
+
+	if err != nil {
+		return fmt.Errorf("Error while deleting logical DHCP port %s: %v", lpID, err)
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		log.Printf("[DEBUG] Logical DHCP port %s was not found", lpID)
+		d.SetId("")
+	}
+
+	return nil
+}

--- a/nsxt/resource_nsxt_logical_dhcp_port_test.go
+++ b/nsxt/resource_nsxt_logical_dhcp_port_test.go
@@ -1,0 +1,133 @@
+/* Copyright © 2017 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"testing"
+)
+
+func TestAccResourceNsxtLogicalDhcpPort_basic(t *testing.T) {
+	portName := fmt.Sprintf("test-nsx-logical-dhcp-port")
+	updatePortName := fmt.Sprintf("%s-update", portName)
+	testResourceName := "nsxt_logical_dhcp_port.test"
+	transportZoneName := getOverlayTransportZoneName()
+	edgeClusterName := getEdgeClusterName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNSXLogicalPortCheckDestroy(state, portName)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNSXLogicalDhcpPortCreateTemplate(portName, transportZoneName, edgeClusterName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNSXLogicalPortExists(portName, testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", portName),
+					resource.TestCheckResourceAttr(testResourceName, "description", "Acceptance Test"),
+					resource.TestCheckResourceAttr(testResourceName, "admin_state", "UP"),
+					resource.TestCheckResourceAttrSet(testResourceName, "logical_switch_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "dhcp_server_id"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
+				),
+			},
+			{
+				Config: testAccNSXLogicalDhcpPortUpdateTemplate(updatePortName, transportZoneName, edgeClusterName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNSXLogicalPortExists(updatePortName, testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", updatePortName),
+					resource.TestCheckResourceAttr(testResourceName, "description", "Acceptance Test Update"),
+					resource.TestCheckResourceAttr(testResourceName, "admin_state", "UP"),
+					resource.TestCheckResourceAttrSet(testResourceName, "logical_switch_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "dhcp_server_id"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtLogicalDhcpPort_importBasic(t *testing.T) {
+	portName := fmt.Sprintf("test-nsx-logical-dhcp-port")
+	testResourceName := "nsxt_logical_dhcp_port.test"
+	transportZoneName := getOverlayTransportZoneName()
+	edgeClusterName := getEdgeClusterName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNSXLogicalPortCheckDestroy(state, portName)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNSXLogicalDhcpPortCreateTemplate(portName, transportZoneName, edgeClusterName),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccNSXDHCPServerCreateForPort(edgeClusterName string) string {
+	return fmt.Sprintf(`
+data "nsxt_edge_cluster" "EC" {
+  display_name = "%s"
+}
+
+resource "nsxt_dhcp_server_profile" "test" {
+  display_name    = "dhcp_server"
+  edge_cluster_id = "${data.nsxt_edge_cluster.EC.id}"
+}
+resource "nsxt_logical_dhcp_server" "test" {
+  display_name     = "server1"
+  dhcp_profile_id  = "${nsxt_dhcp_server_profile.test.id}"
+  dhcp_server_ip   = "1.1.1.1/24"
+  gateway_ip       = "1.1.1.2"
+}`, edgeClusterName)
+}
+
+func testAccNSXLogicalDhcpPortCreateTemplate(portName string, transportZoneName string, edgeClusterName string) string {
+	return testAccNSXLogicalSwitchCreateForPort(transportZoneName) + testAccNSXDHCPServerCreateForPort(edgeClusterName) + fmt.Sprintf(`
+resource "nsxt_logical_dhcp_port" "test" {
+  display_name      = "%s"
+  admin_state       = "UP"
+  description       = "Acceptance Test"
+  logical_switch_id = "${nsxt_logical_switch.test.id}"
+  dhcp_server_id    = "${nsxt_logical_dhcp_server.test.id}"
+
+  tag {
+  	scope = "scope1"
+    tag   = "tag1"
+  }
+}`, portName)
+}
+
+func testAccNSXLogicalDhcpPortUpdateTemplate(portUpdatedName string, transportZoneName string, edgeClusterName string) string {
+	return testAccNSXLogicalSwitchCreateForPort(transportZoneName) + testAccNSXDHCPServerCreateForPort(edgeClusterName) + fmt.Sprintf(`
+resource "nsxt_logical_dhcp_port" "test" {
+  display_name      = "%s"
+  admin_state       = "UP"
+  description       = "Acceptance Test Update"
+  logical_switch_id = "${nsxt_logical_switch.test.id}"
+  dhcp_server_id    = "${nsxt_logical_dhcp_server.test.id}"
+
+  tag {
+    scope = "scope1"
+    tag   = "tag1"
+  }
+
+  tag {
+    scope = "scope2"
+    tag   = "tag2"
+  }
+}`, portUpdatedName)
+}

--- a/nsxt/resource_nsxt_logical_dhcp_server_test.go
+++ b/nsxt/resource_nsxt_logical_dhcp_server_test.go
@@ -73,6 +73,60 @@ func TestAccResourceNsxtLogicalDhcpServer_basic(t *testing.T) {
 	})
 }
 
+func TestAccResourceNsxtLogicalDhcpServer_noOpts(t *testing.T) {
+	prfName := fmt.Sprintf("test-nsx-logical-dhcp-server")
+	updatePrfName := fmt.Sprintf("%s-update", prfName)
+	testResourceName := "nsxt_logical_dhcp_server.test"
+	edgeClusterName := getEdgeClusterName()
+	ip1 := "1.1.1.10/24"
+	ip2 := "1.1.1.20"
+	ip1upd := "2.1.1.10/24"
+	ip2upd := "2.1.1.20"
+	ip3 := "1.1.1.21"
+	ip4 := "1.1.1.22"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNSXLogicalDhcpServerCheckDestroy(state, prfName)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNSXLogicalDhcpServerCreateNoOptsTemplate(edgeClusterName, prfName, ip1, ip2, ip3),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNSXLogicalDhcpServerExists(prfName, testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", prfName),
+					resource.TestCheckResourceAttr(testResourceName, "description", "Acceptance Test"),
+					resource.TestCheckResourceAttrSet(testResourceName, "dhcp_profile_id"),
+					resource.TestCheckResourceAttr(testResourceName, "dhcp_server_ip", ip1),
+					resource.TestCheckResourceAttr(testResourceName, "gateway_ip", ip2),
+					resource.TestCheckResourceAttr(testResourceName, "dns_name_servers.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "dns_name_servers.0", ip3),
+					resource.TestCheckResourceAttr(testResourceName, "dhcp_option_121.#", "0"),
+					resource.TestCheckResourceAttr(testResourceName, "dhcp_generic_option.#", "0"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
+				),
+			},
+			{
+				Config: testAccNSXLogicalDhcpServerUpdateNoOptsTemplate(edgeClusterName, updatePrfName, ip1upd, ip2upd, ip3, ip4),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNSXLogicalDhcpServerExists(updatePrfName, testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", updatePrfName),
+					resource.TestCheckResourceAttr(testResourceName, "description", "Acceptance Test Update"),
+					resource.TestCheckResourceAttrSet(testResourceName, "dhcp_profile_id"),
+					resource.TestCheckResourceAttr(testResourceName, "dhcp_server_ip", ip1upd),
+					resource.TestCheckResourceAttr(testResourceName, "gateway_ip", ip2upd),
+					resource.TestCheckResourceAttr(testResourceName, "dns_name_servers.#", "2"),
+					resource.TestCheckResourceAttr(testResourceName, "dhcp_option_121.#", "0"),
+					resource.TestCheckResourceAttr(testResourceName, "dhcp_generic_option.#", "0"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "2"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccResourceNsxtLogicalDhcpServer_importBasic(t *testing.T) {
 	prfName := fmt.Sprintf("test-nsx-logical-dhcp-server")
 	testResourceName := "nsxt_logical_dhcp_server.test"
@@ -208,7 +262,7 @@ resource "nsxt_logical_dhcp_server" "test" {
   }
 
   dhcp_option_121 {
-    network  = "6.6.6.6/24"
+    network  = "6.6.6.0/24"
     next_hop = "%s"
   }
 
@@ -227,4 +281,45 @@ resource "nsxt_logical_dhcp_server" "test" {
     tag   = "tag2"
   }
 }`, updatedName, ip1, ip2, ip3, ip4, ip5, ip5)
+}
+
+func testAccNSXLogicalDhcpServerCreateNoOptsTemplate(edgeClusterName string, name string, ip1 string, ip2 string, ip3 string) string {
+	return testAccNSXDhcpServerProfileCreateForServerTemplate(edgeClusterName) + fmt.Sprintf(`
+resource "nsxt_logical_dhcp_server" "test" {
+  display_name     = "%s"
+  description      = "Acceptance Test"
+  dhcp_profile_id  = "${nsxt_dhcp_server_profile.PRF.id}"
+  dhcp_server_ip   = "%s"
+  gateway_ip       = "%s"
+  domain_name      = "abc.com"
+  dns_name_servers = ["%s"]
+
+  tag {
+    scope = "scope1"
+    tag   = "tag1"
+  }
+}`, name, ip1, ip2, ip3)
+}
+
+func testAccNSXLogicalDhcpServerUpdateNoOptsTemplate(edgeClusterName string, updatedName string, ip1 string, ip2 string, ip3 string, ip4 string) string {
+	return testAccNSXDhcpServerProfileCreateForServerTemplate(edgeClusterName) + fmt.Sprintf(`
+resource "nsxt_logical_dhcp_server" "test" {
+  display_name     = "%s"
+  description      = "Acceptance Test Update"
+  dhcp_profile_id  = "${nsxt_dhcp_server_profile.PRF.id}"
+  dhcp_server_ip   = "%s"
+  gateway_ip       = "%s"
+  domain_name      = "abc.com"
+  dns_name_servers = ["%s", "%s"]
+
+  tag {
+    scope = "scope1"
+    tag   = "tag1"
+  }
+
+  tag {
+    scope = "scope2"
+    tag   = "tag2"
+  }
+}`, updatedName, ip1, ip2, ip3, ip4)
 }

--- a/website/docs/r/logical_dhcp_port.html.markdown
+++ b/website/docs/r/logical_dhcp_port.html.markdown
@@ -1,0 +1,70 @@
+---
+layout: "nsxt"
+page_title: "NSXT: nsxt_logical_dhcp_port"
+sidebar_current: "docs-nsxt-resource-logical-dhcp-port"
+description: A resource that can be used to configure a Logical DHCP Port in NSX.
+---
+
+# nsxt_logical_dhcp_port
+
+This resource provides a resource to configure a logical port on a logical switch, and attach it to a DHCP server.
+
+## Example Usage
+
+```hcl
+resource "nsxt_logical_dhcp_server" "logical_dhcp_server" {
+  display_name    = "logical_dhcp_server"
+  dhcp_profile_id = "${nsxt_dhcp_server_profile.PRF.id}"
+  dhcp_server_ip  = "1.1.1.10/24"
+  gateway_ip      = "1.1.1.20"
+}
+
+resource "nsxt_logical_switch" "switch" {
+  display_name      = "LS1"
+  admin_state       = "UP"
+  transport_zone_id = "${data.nsxt_transport_zone.transport_zone.id}"
+}
+
+resource "nsxt_logical_dhcp_port" "dhcp_port" {
+  admin_state       = "UP"
+  description       = "LP1 provisioned by Terraform"
+  display_name      = "LP1"
+  logical_switch_id = "${nsxt_logical_switch.switch.id}"
+  dhcp_server_id    = "${nsxt_logical_dhcp_server.logical_dhcp_server.id}"
+
+  tag {
+    scope = "color"
+    tag   = "blue"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `display_name` - (Optional) Display name, defaults to ID if not set.
+* `description` - (Optional) Description of this resource.
+* `logical_switch_id` - (Required) Logical switch ID for the logical port.
+* `dhcp_server_id` - (Required) Logical DHCP server ID for the logical port.
+* `admin_state` - (Optional) Admin state for the logical port. Accepted values - 'UP' or 'DOWN'. The default value is 'UP'.
+* `tag` - (Optional) A list of scope + tag pairs to associate with this logical port.
+
+## Attributes Reference
+
+In addition to arguments listed above, the following attributes are exported:
+
+* `id` - ID of the logical switch.
+* `revision` - Indicates current revision number of the object as seen by NSX-T API server. This attribute can be useful for debugging.
+
+## Importing
+
+An existing Logical Port can be [imported][docs-import] into this resource, via the following command:
+
+[docs-import]: /docs/import/index.html
+
+```
+terraform import nsxt_logical_dhcp_port.dhcp_port UUID
+```
+
+The above command imports the logical DHCP port named `dhcp_port` with the NSX id `UUID`.

--- a/website/nsxt.erb
+++ b/website/nsxt.erb
@@ -58,11 +58,14 @@
                         <li<%= sidebar_current("docs-nsxt-resource-ip-set") %>>
                             <a href="/docs/providers/nsxt/r/ip_set.html">nsxt_ip_set</a>
                         </li>
-                        <li<%= sidebar_current("docs-nsxt-resource-logical-port") %>>
-                            <a href="/docs/providers/nsxt/r/logical_port.html">nsxt_logical_port</a>
-                        </li>
                         <li<%= sidebar_current("docs-nsxt-resource-logical-dhcp-server") %>>
                             <a href="/docs/providers/nsxt/r/logical_dhcp_server.html">nsxt_logical_dhcp_server</a>
+                        </li>
+                        <li<%= sidebar_current("docs-nsxt-resource-logical-dhcp-port") %>>
+                            <a href="/docs/providers/nsxt/r/logical_dhcp_port.html">nsxt_logical_dhcp_port</a>
+                        </li>
+                        <li<%= sidebar_current("docs-nsxt-resource-logical-port") %>>
+                            <a href="/docs/providers/nsxt/r/logical_port.html">nsxt_logical_port</a>
                         </li>
                         <li<%= sidebar_current("docs-nsxt-resource-logical-router-downlink-port") %>>
                             <a href="/docs/providers/nsxt/r/logical_router_downlink_port.html">nsxt_logical_router_downlink_port</a>


### PR DESCRIPTION
This resource will create a logical port on a logical switch with
an attachment to a DHCP server.
In addition - Fixing and improving the logical dhcp server resource and tests.