### PR TITLE
Adjust ICMP test to latest backend

### DIFF
--- a/nsxt/resource_nsxt_icmp_type_ns_service_test.go
+++ b/nsxt/resource_nsxt_icmp_type_ns_service_test.go
@@ -37,7 +37,7 @@ func TestAccResourceNsxtIcmpTypeNsService_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNSXIcmpServiceCreateTemplate(updateServiceName, "ICMPv6", 3, 1),
+				Config: testAccNSXIcmpServiceCreateTemplate(updateServiceName, "ICMPv6", 139, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNSXIcmpServiceExists(updateServiceName, testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "display_name", updateServiceName),


### PR DESCRIPTION
Some ICMP type/code combinations were removed from NSX support.
This commit adjust tests accordingly.