### PR TITLE
Adding cascade delete for LS

### DIFF
--- a/nsxt/resource_nsxt_logical_switch.go
+++ b/nsxt/resource_nsxt_logical_switch.go
@@ -269,6 +269,7 @@ func resourceNsxtLogicalSwitchDelete(d *schema.ResourceData, m interface{}) erro
 	}
 
 	localVarOptionals := make(map[string]interface{})
+	localVarOptionals["cascade"] = true
 	resp, err := nsxClient.LogicalSwitchingApi.DeleteLogicalSwitch(nsxClient.Context, id, localVarOptionals)
 	if err != nil {
 		return fmt.Errorf("Error during LogicalSwitch delete: %v", err)


### PR DESCRIPTION
Cascade delete would delete all ports on logical switch.
Since we assume all configuration is created by terraform, terraform
should take care of all switch dependencies before deleting the switch.
Cascade delete would help to clean up dangling ports that result from
errors (for example, on vpshere provider side).