### PR TITLE
Fix http version validation in LB resources

### DIFF
--- a/nsxt/lb_rule_utils.go
+++ b/nsxt/lb_rule_utils.go
@@ -112,7 +112,7 @@ func getLbRuleHTTPVersionConditionSchema() *schema.Schema {
 				"version": &schema.Schema{
 					Type:         schema.TypeString,
 					Required:     true,
-					ValidateFunc: validation.StringInSlice([]string{"HTTP_VERSION_1_0", "HTTP_VERSION_1_1", "HTTP_VERSION_2_0"}, false),
+					ValidateFunc: validation.StringInSlice([]string{"HTTP_VERSION_1_0", "HTTP_VERSION_1_1"}, false),
 				},
 			},
 		},

--- a/nsxt/lb_utils.go
+++ b/nsxt/lb_utils.go
@@ -91,7 +91,7 @@ func getLbMonitorRequestVersionSchema() *schema.Schema {
 		Type:         schema.TypeString,
 		Description:  "HTTP request version",
 		Optional:     true,
-		ValidateFunc: validation.StringInSlice([]string{"HTTP_VERSION_1_0", "HTT    P_VERSION_1_1", "HTTP_VERSION_1_2"}, false),
+		ValidateFunc: validation.StringInSlice([]string{"HTTP_VERSION_1_0", "HTTP_VERSION_1_1"}, false),
 		Default:      "HTTP_VERSION_1_1",
 	}
 }
@@ -99,7 +99,7 @@ func getLbMonitorRequestVersionSchema() *schema.Schema {
 func getLbMonitorResponseBodySchema() *schema.Schema {
 	return &schema.Schema{
 		Type:        schema.TypeString,
-		Description: "If HTTP response body string is specified then the healthcheck HTTP response body is matched against the specified string (regular expressions not supported), and server is considered healthy only if there is a match. If response body string is not specified, HTTP healthcheck is considered successful if the HTTP response status code matches configured value.",
+		Description: "If HTTP specified, healthcheck HTTP response body is matched against the specified string (regular expressions not supported), and succeeds only if there is a match",
 		Optional:    true,
 	}
 }

--- a/website/docs/r/lb_http_forwarding_rule.html.markdown
+++ b/website/docs/r/lb_http_forwarding_rule.html.markdown
@@ -180,7 +180,7 @@ The following arguments are supported:
   * `inverse` - (Optional) A flag to indicate whether reverse the match result of this condition. Default is false.
 
 * `version_condition` - (Optional) Match condition used to match http version of the request:
-  * `method` - (Required) One of GET, HEAD, POST, PUT, OPTIONS.
+  * `version` - (Required) One of HTTP_VERSION_1_0, HTTP_VERSION_1_1.
   * `inverse` - (Optional) A flag to indicate whether reverse the match result of this condition. Default is false.
 
 * `ip_condition` - (Optional) Set of match conditions used to match IP header values of HTTP request:

--- a/website/docs/r/lb_http_monitor.html.markdown
+++ b/website/docs/r/lb_http_monitor.html.markdown
@@ -55,9 +55,9 @@ The following arguments are supported:
 * `timeout` - (Optional) Number of seconds the target has to respond to the monitor request.
 * `request_body` - (Optional) String to send as HTTP health check request body. Valid only for certain HTTP methods like POST.
 * `request_header` - (Optional) HTTP request headers.
-* `request_method` - (Optional) Health check method for HTTP monitor type.
+* `request_method` - (Optional) Health check method for HTTP monitor type. Valid values are GET, HEAD, PUT, POST and OPTIONS.
 * `request_url` - (Optional) URL used for HTTP monitor.
-* `request_version` - (Optional) HTTP request version.
+* `request_version` - (Optional) HTTP request version. Valid values are HTTP_VERSION_1_0 and HTTP_VERSION_1_1.
 * `response_body` - (Optional) If response body is specified, healthcheck HTTP response body is matched against the specified string and server is considered healthy only if there is a match (regular expressions not supported). If response body string is not specified, HTTP healthcheck is considered successful if the HTTP response status code is among configured values.
 * `response_status_codes` - (Optional) HTTP response status code should be a valid HTTP status code.
 

--- a/website/docs/r/lb_http_request_rewrite_rule.html.markdown
+++ b/website/docs/r/lb_http_request_rewrite_rule.html.markdown
@@ -183,7 +183,7 @@ The following arguments are supported:
   * `inverse` - (Optional) A flag to indicate whether reverse the match result of this condition. Default is false.
 
 * `version_condition` - (Optional) Match condition used to match http version of the request:
-  * `method` - (Required) One of GET, HEAD, POST, PUT, OPTIONS.
+  * `version` - (Required) One of HTTP_VERSION_1_0, HTTP_VERSION_1_1.
   * `inverse` - (Optional) A flag to indicate whether reverse the match result of this condition. Default is false.
 
 * `uri_arguments_condition` - (Optional) Set of match conditions used to match http request URI arguments(query string):

--- a/website/docs/r/lb_http_response_rewrite_rule.html.markdown
+++ b/website/docs/r/lb_http_response_rewrite_rule.html.markdown
@@ -182,7 +182,7 @@ The following arguments are supported:
   * `inverse` - (Optional) A flag to indicate whether reverse the match result of this condition. Default is false.
 
 * `version_condition` - (Optional) Match condition used to match http version of the request:
-  * `method` - (Required) One of GET, HEAD, POST, PUT, OPTIONS.
+  * `version` - (Required) One of HTTP_VERSION_1_0, HTTP_VERSION_1_1.
   * `inverse` - (Optional) A flag to indicate whether reverse the match result of this condition. Default is false.
 
 * `uri_arguments_condition` - (Optional) Set of match conditions used to match http request URI arguments(query string):

--- a/website/docs/r/lb_https_monitor.html.markdown
+++ b/website/docs/r/lb_https_monitor.html.markdown
@@ -74,9 +74,9 @@ The following arguments are supported:
 * `protocols` - (Optional) SSL versions TLS1.1 and TLS1.2 are supported and enabled by default. SSLv2, SSLv3, and TLS1.0 are supported, but disabled by default.
 * `request_body` - (Optional) String to send as HTTP health check request body. Valid only for certain HTTP methods like POST.
 * `request_header` - (Optional) HTTP request headers.
-* `request_method` - (Optional) Health check method for HTTP monitor type.
+* `request_method` - (Optional) Health check method for HTTP monitor type. Valid values are GET, HEAD, PUT, POST and OPTIONS.
 * `request_url` - (Optional) URL used for HTTP monitor.
-* `request_version` - (Optional) HTTP request version.
+* `request_version` - (Optional) HTTP request version. Valid values are HTTP_VERSION_1_0 and HTTP_VERSION_1_1.
 * `response_body` - (Optional) If response body is specified, healthcheck HTTP response body is matched against the specified string and server is considered healthy only if there is a match (regular expressions not supported). If response body string is not specified, HTTP healthcheck is considered successful if the HTTP response status code is among configured values.
 * `response_status_codes` - (Optional) HTTP response status code should be a valid HTTP status code.
 * `server_auth` - (Optional) Server authentication mode - REQUIRED or IGNORE.


### PR DESCRIPTION
HTTP_VERSION_2_0 is not supported in current platform, although
declared in spec. This option will be added here when backed by
platform.