### PR TITLE
Adding NS Service Group resource

### DIFF
--- a/nsxt/provider.go
+++ b/nsxt/provider.go
@@ -112,6 +112,7 @@ func Provider() terraform.ResourceProvider {
 			"nsxt_igmp_type_ns_service":                    resourceNsxtIgmpTypeNsService(),
 			"nsxt_ether_type_ns_service":                   resourceNsxtEtherTypeNsService(),
 			"nsxt_ip_protocol_ns_service":                  resourceNsxtIPProtocolNsService(),
+			"nsxt_ns_service_group":                        resourceNsxtNsServiceGroup(),
 			"nsxt_ns_group":                                resourceNsxtNsGroup(),
 			"nsxt_firewall_section":                        resourceNsxtFirewallSection(),
 			"nsxt_nat_rule":                                resourceNsxtNatRule(),

--- a/nsxt/resource_nsxt_algorithm_type_ns_service.go
+++ b/nsxt/resource_nsxt_algorithm_type_ns_service.go
@@ -184,6 +184,7 @@ func resourceNsxtAlgorithmTypeNsServiceDelete(d *schema.ResourceData, m interfac
 	}
 
 	localVarOptionals := make(map[string]interface{})
+	localVarOptionals["force"] = true
 	resp, err := nsxClient.GroupingObjectsApi.DeleteNSService(nsxClient.Context, id, localVarOptionals)
 	if err != nil {
 		return fmt.Errorf("Error during NsService delete: %v", err)

--- a/nsxt/resource_nsxt_ether_type_ns_service.go
+++ b/nsxt/resource_nsxt_ether_type_ns_service.go
@@ -153,6 +153,7 @@ func resourceNsxtEtherTypeNsServiceDelete(d *schema.ResourceData, m interface{})
 	}
 
 	localVarOptionals := make(map[string]interface{})
+	localVarOptionals["force"] = true
 	resp, err := nsxClient.GroupingObjectsApi.DeleteNSService(nsxClient.Context, id, localVarOptionals)
 	if err != nil {
 		return fmt.Errorf("Error during NsService delete: %v", err)

--- a/nsxt/resource_nsxt_icmp_type_ns_service.go
+++ b/nsxt/resource_nsxt_icmp_type_ns_service.go
@@ -179,6 +179,7 @@ func resourceNsxtIcmpTypeNsServiceDelete(d *schema.ResourceData, m interface{}) 
 	}
 
 	localVarOptionals := make(map[string]interface{})
+	localVarOptionals["force"] = true
 	resp, err := nsxClient.GroupingObjectsApi.DeleteNSService(nsxClient.Context, id, localVarOptionals)
 	if err != nil {
 		return fmt.Errorf("Error during NsService delete: %v", err)

--- a/nsxt/resource_nsxt_igmp_type_ns_service.go
+++ b/nsxt/resource_nsxt_igmp_type_ns_service.go
@@ -141,6 +141,7 @@ func resourceNsxtIgmpTypeNsServiceDelete(d *schema.ResourceData, m interface{}) 
 	}
 
 	localVarOptionals := make(map[string]interface{})
+	localVarOptionals["force"] = true
 	resp, err := nsxClient.GroupingObjectsApi.DeleteNSService(nsxClient.Context, id, localVarOptionals)
 	if err != nil {
 		return fmt.Errorf("Error during NsService delete: %v", err)

--- a/nsxt/resource_nsxt_ip_protocol_ns_service.go
+++ b/nsxt/resource_nsxt_ip_protocol_ns_service.go
@@ -155,6 +155,7 @@ func resourceNsxtIPProtocolNsServiceDelete(d *schema.ResourceData, m interface{}
 	}
 
 	localVarOptionals := make(map[string]interface{})
+	localVarOptionals["force"] = true
 	resp, err := nsxClient.GroupingObjectsApi.DeleteNSService(nsxClient.Context, id, localVarOptionals)
 	if err != nil {
 		return fmt.Errorf("Error during NsService delete: %v", err)

--- a/nsxt/resource_nsxt_l4_port_set_ns_service.go
+++ b/nsxt/resource_nsxt_l4_port_set_ns_service.go
@@ -185,6 +185,7 @@ func resourceNsxtL4PortSetNsServiceDelete(d *schema.ResourceData, m interface{})
 	}
 
 	localVarOptionals := make(map[string]interface{})
+	localVarOptionals["force"] = true
 	resp, err := nsxClient.GroupingObjectsApi.DeleteNSService(nsxClient.Context, id, localVarOptionals)
 	if err != nil {
 		return fmt.Errorf("Error during NsService delete: %v", err)

--- a/nsxt/resource_nsxt_ns_service_group.go
+++ b/nsxt/resource_nsxt_ns_service_group.go
@@ -52,10 +52,10 @@ func resourceNsxtNsServiceGroup() *schema.Resource {
 func getResourceReferencesFromStringsSet(d *schema.ResourceData, schemaAttrName string) []common.ResourceReference {
 	targetIds := interface2StringList(d.Get(schemaAttrName).(*schema.Set).List())
 	var referenceList []common.ResourceReference
-	for _, targetId := range targetIds {
+	for _, targetID := range targetIds {
 		elem := common.ResourceReference{
 			IsValid:    true,
-			TargetId:   targetId,
+			TargetId:   targetID,
 			TargetType: "NSService",
 		}
 

--- a/nsxt/resource_nsxt_ns_service_group_test.go
+++ b/nsxt/resource_nsxt_ns_service_group_test.go
@@ -1,0 +1,175 @@
+/* Copyright © 2017 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/vmware/go-vmware-nsxt"
+	"net/http"
+	"testing"
+)
+
+func TestAccResourceNsxtNsServiceGroup_basic(t *testing.T) {
+	serviceName := fmt.Sprintf("test-nsx-service-group-for-import")
+	updateServiceName := fmt.Sprintf("%s-update", serviceName)
+	testResourceName := "nsxt_ns_service_group.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNSXServiceGroupCheckDestroy(state, serviceName)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNSXServiceGroupCreateTemplate(serviceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNSXServiceGroupExists(serviceName, testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", serviceName),
+					resource.TestCheckResourceAttr(testResourceName, "description", "service group"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "members.#", "1"),
+				),
+			},
+			{
+				Config: testAccNSXServiceGroupUpdateTemplate(updateServiceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNSXServiceGroupExists(updateServiceName, testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", updateServiceName),
+					resource.TestCheckResourceAttr(testResourceName, "description", "service group"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "2"),
+					resource.TestCheckResourceAttr(testResourceName, "members.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtNsServiceGroup_importBasic(t *testing.T) {
+	serviceName := fmt.Sprintf("test-nsx-service-group")
+	testResourceName := "nsxt_ns_service_group.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNSXServiceGroupCheckDestroy(state, serviceName)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNSXServiceGroupCreateTemplate(serviceName),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccNSXServiceGroupExists(displayName string, resourceName string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+
+		nsxClient := testAccProvider.Meta().(*nsxt.APIClient)
+
+		rs, ok := state.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("NSX service group resource %s not found in resources", resourceName)
+		}
+
+		resourceID := rs.Primary.ID
+		if resourceID == "" {
+			return fmt.Errorf("NSX service group resource ID not set in resources ")
+		}
+
+		service, responseCode, err := nsxClient.GroupingObjectsApi.ReadNSServiceGroup(nsxClient.Context, resourceID)
+		if err != nil {
+			return fmt.Errorf("Error while retrieving service group ID %s. Error: %v", resourceID, err)
+		}
+
+		if responseCode.StatusCode != http.StatusOK {
+			return fmt.Errorf("Error while checking if service group %s exists. HTTP return code was %d", resourceID, responseCode.StatusCode)
+		}
+
+		if displayName == service.DisplayName {
+			return nil
+		}
+		return fmt.Errorf("NSX NS service group %s wasn't found", displayName)
+	}
+}
+
+func testAccNSXServiceGroupCheckDestroy(state *terraform.State, displayName string) error {
+	nsxClient := testAccProvider.Meta().(*nsxt.APIClient)
+
+	for _, rs := range state.RootModule().Resources {
+
+		if rs.Type != "nsxt_ns_service_group" {
+			continue
+		}
+
+		resourceID := rs.Primary.Attributes["id"]
+		service, responseCode, err := nsxClient.GroupingObjectsApi.ReadNSServiceGroup(nsxClient.Context, resourceID)
+		if err != nil {
+			if responseCode.StatusCode != http.StatusOK {
+				return nil
+			}
+			return fmt.Errorf("Error while retrieving NS service group ID %s. Error: %v", resourceID, err)
+		}
+
+		if displayName == service.DisplayName {
+			return fmt.Errorf("NSX NS service group %s still exists", displayName)
+		}
+	}
+	return nil
+}
+
+func testAccNSXServiceGroupCreateServices() string {
+	return fmt.Sprintf(`
+resource "nsxt_ip_protocol_ns_service" "srv1" {
+  display_name = "test_ip_protocol_service"
+  protocol     = "17"
+}
+
+resource "nsxt_l4_port_set_ns_service" "srv2" {
+  display_name      = "test_l4_service"
+  protocol          = "TCP"
+  destination_ports = [ "8080" ]
+}`)
+}
+
+func testAccNSXServiceGroupCreateTemplate(serviceName string) string {
+	return testAccNSXServiceGroupCreateServices() + fmt.Sprintf(`
+resource "nsxt_ns_service_group" "test" {
+  description  = "service group"
+  display_name = "%s"
+  members      = ["${nsxt_ip_protocol_ns_service.srv1.id}"]
+
+  tag {
+    scope = "scope1"
+    tag   = "tag1"
+  }
+}`, serviceName)
+}
+
+func testAccNSXServiceGroupUpdateTemplate(serviceName string) string {
+	return testAccNSXServiceGroupCreateServices() + fmt.Sprintf(`
+resource "nsxt_ns_service_group" "test" {
+  description  = "service group"
+  display_name = "%s"
+  members      = ["${nsxt_ip_protocol_ns_service.srv1.id}", "${nsxt_l4_port_set_ns_service.srv2.id}"]
+
+  tag {
+    scope = "scope1"
+    tag   = "tag1"
+  }
+
+  tag {
+    scope = "scope2"
+    tag   = "tag2"
+  }
+}`, serviceName)
+}

--- a/website/docs/r/ns_service_group.html.markdown
+++ b/website/docs/r/ns_service_group.html.markdown
@@ -42,7 +42,7 @@ The following arguments are supported:
 * `description` - (Optional) Description of this resource.
 * `display_name` - (Optional) The display name of this resource. Defaults to ID if not set.
 * `tag` - (Optional) A list of scope + tag pairs to associate with this NS service group.
-* `members` - (Optional) List of NSServices IDs that can be added as members to an NSServiceGroup. All members should be of the same type : Ethernet, or Non Ethernet.
+* `members` - (Required) List of NSServices IDs that can be added as members to an NSServiceGroup. All members should be of the same L2 type: Ethernet, or Non Ethernet.
 
 
 ## Attributes Reference

--- a/website/docs/r/ns_service_group.html.markdown
+++ b/website/docs/r/ns_service_group.html.markdown
@@ -1,0 +1,66 @@
+---
+layout: "nsxt"
+page_title: "NSXT: nsxt_ns_service_group"
+sidebar_current: "docs-nsxt-ns-service-resource-service_group"
+description: |-
+  Provides a resource to configure NS service group on NSX-T manager
+---
+
+# nsxt_ns_service_group
+
+Provides a resource to configure NS service group on NSX-T manager
+
+## Example Usage
+
+```hcl
+
+data "nsxt_ns_service" "dns" {
+  display_name = "DNS"
+}
+
+resource "nsxt_ip_protocol_ns_service" "prot17" {
+  display_name = "ip_prot"
+  protocol     = "17"
+}
+
+resource "nsxt_ns_service_group" "ns_service_group" {
+  description  = "ns_service_group provisioned by Terraform"
+  display_name = "ns_service_group"
+  members      = ["${nsxt_ip_protocol_ns_service.prot17.id}", "${data.nsxt_ns_service.dns.id}"]
+
+  tag = {
+    scope = "color"
+    tag   = "red"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `description` - (Optional) Description of this resource.
+* `display_name` - (Optional) The display name of this resource. Defaults to ID if not set.
+* `tag` - (Optional) A list of scope + tag pairs to associate with this NS service group.
+* `members` - (Optional) List of NSServices IDs that can be added as members to an NSServiceGroup. All members should be of the same type : Ethernet, or Non Ethernet.
+
+
+## Attributes Reference
+
+In addition to arguments listed above, the following attributes are exported:
+
+* `id` - ID of the NS service group.
+* `revision` - Indicates current revision number of the object as seen by NSX-T API server. This attribute can be useful for debugging.
+
+
+## Importing
+
+An existing ns service group can be [imported][docs-import] into this resource, via the following command:
+
+[docs-import]: /docs/import/index.html
+
+```
+terraform import nsxt_ns_service_group.ns_service_group UUID
+```
+
+The above would import the NS service group named `ns_service_group` with the nsx id `UUID`

--- a/website/nsxt.erb
+++ b/website/nsxt.erb
@@ -169,6 +169,9 @@
                         <li<%= sidebar_current("docs-nsxt-ns-service-resource-l4-port-set") %>>
                             <a href="/docs/providers/nsxt/r/l4_port_set_ns_service.html">nsxt_l4_port_set_ns_service</a>
                         </li>
+                        <li<%= sidebar_current("docs-nsxt-ns-service-resource-service_group") %>>
+                            <a href="/docs/providers/nsxt/r/ns_service_group.html">nsxt_ns_service_group</a>
+                        </li>
                     </ul>
                 </li>
 


### PR DESCRIPTION
The Service group contains NS services of any type as its members.
Please Note - nested NS services groups is currently not supported
by the NSX backend, although the api exists.