### PR TITLE
Fix icmp_code in icmp_type_ns_service resource

### DIFF
--- a/vendor/github.com/vmware/go-vmware-nsxt/manager/icmp_type_ns_service.go
+++ b/vendor/github.com/vmware/go-vmware-nsxt/manager/icmp_type_ns_service.go
@@ -9,7 +9,7 @@ type IcmpTypeNsServiceEntry struct {
 	ResourceType string `json:"resource_type"`
 
 	// ICMP message code
-	IcmpCode int64 `json:"icmp_code,omitempty"`
+	IcmpCode int64 `json:"icmp_code"`
 
 	// ICMP message type
 	IcmpType int64 `json:"icmp_type,omitempty"`

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -2332,10 +2332,10 @@
 			"revisionTime": "2018-06-24T05:57:26Z"
 		},
 		{
-			"checksumSHA1": "HbcJpXjpUPNZKFSZsReMwxeXh44=",
+			"checksumSHA1": "TZ0j6fjnZNDyTcWrqXc5ueLqJvU=",
 			"path": "github.com/vmware/go-vmware-nsxt/manager",
-			"revision": "36b9ba8db5450aff8cda926fa135a660491425a0",
-			"revisionTime": "2018-06-24T05:57:26Z"
+			"revision": "23af5e753efe280311318a7b4f3b9525c838da2e",
+			"revisionTime": "2018-07-19T20:01:25Z"
 		},
 		{
 			"checksumSHA1": "NVOWbWEQajRsbUIEwdoTyDP80AM=",


### PR DESCRIPTION
Due to bug in early versions of NSX, icmp_code can not be omitted
from request.