### PR TITLE
Allow unspecified value for max size in LB pool

### DIFF
--- a/nsxt/resource_nsxt_lb_pool_test.go
+++ b/nsxt/resource_nsxt_lb_pool_test.go
@@ -235,6 +235,7 @@ func TestAccResourceNsxtLbPool_withMemberGroup(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "algorithm", algorithm),
 					resource.TestCheckResourceAttr(testResourceName, "member.#", "0"),
 					resource.TestCheckResourceAttr(testResourceName, "member_group.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "member_group.0.limit_ip_list_size", "true"),
 					resource.TestCheckResourceAttr(testResourceName, "member_group.0.max_ip_list_size", size),
 					resource.TestCheckResourceAttr(testResourceName, "member_group.0.ip_version_filter", "IPV4"),
 					resource.TestCheckResourceAttr(testResourceName, "member_group.0.port", port),
@@ -252,6 +253,7 @@ func TestAccResourceNsxtLbPool_withMemberGroup(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "algorithm", algorithm),
 					resource.TestCheckResourceAttr(testResourceName, "member.#", "0"),
 					resource.TestCheckResourceAttr(testResourceName, "member_group.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "member_group.0.limit_ip_list_size", "true"),
 					resource.TestCheckResourceAttr(testResourceName, "member_group.0.max_ip_list_size", updatedSize),
 					resource.TestCheckResourceAttr(testResourceName, "member_group.0.ip_version_filter", "IPV6"),
 					resource.TestCheckResourceAttr(testResourceName, "member_group.0.port", updatedPort),
@@ -560,9 +562,10 @@ resource "nsxt_lb_pool" "test" {
   description           = "Acceptance Test"
 
   member_group {
-    ip_version_filter = "IPV4"
-    max_ip_list_size  = "%s"
-    port              = "%s"
+    ip_version_filter  = "IPV4"
+    limit_ip_list_size = true
+    max_ip_list_size   = %s
+    port               = "%s"
 
     grouping_object {
       target_type = "NSGroup"
@@ -585,9 +588,10 @@ resource "nsxt_lb_pool" "test" {
   description           = "Updated Acceptance Test"
 
   member_group {
-    ip_version_filter = "IPV6"
-    max_ip_list_size  = "%s"
-    port              = "%s"
+    ip_version_filter  = "IPV6"
+    limit_ip_list_size = true
+    max_ip_list_size   = %s
+    port               = "%s"
 
     grouping_object {
       target_type = "NSGroup"

--- a/nsxt/resource_nsxt_lb_pool_test.go
+++ b/nsxt/resource_nsxt_lb_pool_test.go
@@ -215,7 +215,6 @@ func TestAccResourceNsxtLbPool_withMemberGroup(t *testing.T) {
 	testResourceName := "nsxt_lb_pool.test"
 	algorithm := "LEAST_CONNECTION"
 	size := "3"
-	updatedSize := "4"
 	port := "50"
 	updatedPort := "60"
 
@@ -245,7 +244,7 @@ func TestAccResourceNsxtLbPool_withMemberGroup(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNSXLbPoolUpdateWithMemberGroupTemplate(updatedName, algorithm, updatedSize, updatedPort),
+				Config: testAccNSXLbPoolUpdateWithMemberGroupTemplate(updatedName, algorithm, updatedPort),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNSXLbPoolExists(updatedName, testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "display_name", updatedName),
@@ -253,8 +252,8 @@ func TestAccResourceNsxtLbPool_withMemberGroup(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "algorithm", algorithm),
 					resource.TestCheckResourceAttr(testResourceName, "member.#", "0"),
 					resource.TestCheckResourceAttr(testResourceName, "member_group.#", "1"),
-					resource.TestCheckResourceAttr(testResourceName, "member_group.0.limit_ip_list_size", "true"),
-					resource.TestCheckResourceAttr(testResourceName, "member_group.0.max_ip_list_size", updatedSize),
+					resource.TestCheckResourceAttr(testResourceName, "member_group.0.limit_ip_list_size", "false"),
+					resource.TestCheckResourceAttr(testResourceName, "member_group.0.max_ip_list_size", "0"),
 					resource.TestCheckResourceAttr(testResourceName, "member_group.0.ip_version_filter", "IPV6"),
 					resource.TestCheckResourceAttr(testResourceName, "member_group.0.port", updatedPort),
 					resource.TestCheckResourceAttr(testResourceName, "member_group.0.grouping_object.#", "1"),
@@ -576,7 +575,7 @@ resource "nsxt_lb_pool" "test" {
 `, name, algorithm, size, port)
 }
 
-func testAccNSXLbPoolUpdateWithMemberGroupTemplate(name string, algorithm string, size string, port string) string {
+func testAccNSXLbPoolUpdateWithMemberGroupTemplate(name string, algorithm string, port string) string {
 	return fmt.Sprintf(`
 resource "nsxt_ns_group" "grp1" {
   display_name = "grp1"
@@ -589,8 +588,7 @@ resource "nsxt_lb_pool" "test" {
 
   member_group {
     ip_version_filter  = "IPV6"
-    limit_ip_list_size = true
-    max_ip_list_size   = %s
+    limit_ip_list_size = false
     port               = "%s"
 
     grouping_object {
@@ -599,5 +597,5 @@ resource "nsxt_lb_pool" "test" {
     }
   }
 }
-`, name, algorithm, size, port)
+`, name, algorithm, port)
 }

--- a/vendor/github.com/vmware/go-vmware-nsxt/loadbalancer/pool_member_group.go
+++ b/vendor/github.com/vmware/go-vmware-nsxt/loadbalancer/pool_member_group.go
@@ -25,7 +25,8 @@ type PoolMemberGroup struct {
 	IpRevisionFilter string `json:"ip_revision_filter,omitempty"`
 
 	// The size is used to define the maximum number of grouping object IP address list. These IP addresses would be used as pool members. If the grouping object includes more than certain number of IP addresses, the redundant parts would be ignored and those IP addresses would not be treated as pool members.
-	MaxIpListSize int64 `json:"max_ip_list_size"`
+        // In order to destinguish between zero and unspecified value, use pointer
+	MaxIpListSize *int64 `json:"max_ip_list_size,omitempty"`
 
 	// If port is specified, all connections will be sent to this port. If unset, the same port the client connected to will be used, it could be overridden by default_pool_member_ports setting in virtual server. The port should not specified for multiple ports case.
 	Port int32 `json:"port,omitempty"`

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -2326,10 +2326,10 @@
 			"revisionTime": "2018-01-07T08:12:33Z"
 		},
 		{
-			"checksumSHA1": "+bNl9dfUjN96pPzi5BuKgqLm0dY=",
+			"checksumSHA1": "CsBWxmyQlaTwD5Np7xhNGh1gbs8=",
 			"path": "github.com/vmware/go-vmware-nsxt/loadbalancer",
-			"revision": "36b9ba8db5450aff8cda926fa135a660491425a0",
-			"revisionTime": "2018-06-24T05:57:26Z"
+			"revision": "02ced2297288a42d85fdf3f744a797422a73fa62",
+			"revisionTime": "2018-10-02T18:05:17Z"
 		},
 		{
 			"checksumSHA1": "1Aq+4XzgRMdTxNGn5LE+8xIw8ic=",

--- a/website/docs/r/lb_pool.html.markdown
+++ b/website/docs/r/lb_pool.html.markdown
@@ -34,7 +34,7 @@ resource "nsxt_lb_pool" "lb_pool" {
   tcp_multiplexing_number  = 3
   active_monitor_id        = "${nsxt_lb_icmp_monitor.lb_icmp_monitor.id}"
   passive_monitor_id       = "${nsxt_lb_passive_monitor.lb_passive_monitor.id}"
- 
+
   member {
     admin_state                = "ENABLED"
     backup_member              = "false"
@@ -68,9 +68,10 @@ resource "nsxt_lb_pool" "lb_pool_with_dynamic_membership" {
   }
 
   member_group {
-    ip_version_filter = "IPV4"
-    max_ip_list_size  = "4"
-    port              = "80"
+    ip_version_filter   = "IPV4"
+    limit_ip_list_size  = true
+    max_ip_list_size    = "4"
+    port                = "80"
 
     grouping_object {
       target_type = "NSGroup"
@@ -105,7 +106,8 @@ The following arguments are supported:
 * `member_group` - (Optional) Dynamic pool members for the loadbalancing pool. When member group is defined, members setting should not be specified. The member_group has the following arguments:
   * `grouping_object` - (Required) Grouping object of type NSGroup which will be used as dynamic pool members. The IP list of the grouping object would be used as pool member IP setting.
   * `ip_version_filter` - (Optional) Ip version filter is used to filter IPv4 or IPv6 addresses from the grouping object. If the filter is not specified, both IPv4 and IPv6 addresses would be used as server IPs. Supported filtering is "IPV4" and "IPV6" ("IPV4" is the default one)
-  * `max_ip_list_size` - (Optional) The size is used to define the maximum number of grouping object IP address list. These IP addresses would be used as pool members. If the grouping object includes more than certain number of IP addresses, the redundant parts would be ignored and those IP addresses would not be treated as pool members.
+  * `limit_ip_list_size` - (Optional) Limits the max number of pool members. If false, allows the dynamic pool to grow up to the load balancer max pool member capacity.
+  * `max_ip_list_size` - (Optional) Should only be specified if limit_ip_list_size is set to true. Limits the max number of pool members to the specified value.
   * `port` - (Optional) If port is specified, all connections will be sent to this port. If unset, the same port the client connected to will be used, it could be overridden by default_pool_member_ports setting in virtual server. The port should not specified for multiple ports case.
 * `min_active_members` - (Optional) The minimum number of members for the pool to be considered active. This value is 1 by default.
 * `passive_monitor_id` - (Optional) Passive health monitor Id. If one is not set, the passive healthchecks will be disabled.


### PR DESCRIPTION
Introduce another attribute to specify whether to limit number of
addresses in pool.