### PR TITLE
Separate vlan logical switch to dedicated resource

### DIFF
--- a/nsxt/provider.go
+++ b/nsxt/provider.go
@@ -101,6 +101,7 @@ func Provider() terraform.ResourceProvider {
 			"nsxt_logical_dhcp_server":                     resourceNsxtLogicalDhcpServer(),
 			"nsxt_dhcp_server_ip_pool":                     resourceNsxtDhcpServerIPPool(),
 			"nsxt_logical_switch":                          resourceNsxtLogicalSwitch(),
+			"nsxt_vlan_logical_switch":                     resourceNsxtVlanLogicalSwitch(),
 			"nsxt_logical_dhcp_port":                       resourceNsxtLogicalDhcpPort(),
 			"nsxt_logical_port":                            resourceNsxtLogicalPort(),
 			"nsxt_logical_tier0_router":                    resourceNsxtLogicalTier0Router(),

--- a/nsxt/resource_nsxt_logical_switch.go
+++ b/nsxt/resource_nsxt_logical_switch.go
@@ -82,9 +82,9 @@ func resourceNsxtLogicalSwitch() *schema.Resource {
 				ForceNew:    true,
 			},
 			"vlan": &schema.Schema{
-				Type:        schema.TypeInt,
-				Deprecated:  "Use nsxt_vlan_logical_switch resource instead",
-				Optional:    true,
+				Type:       schema.TypeInt,
+				Deprecated: "Use nsxt_vlan_logical_switch resource instead",
+				Optional:   true,
 			},
 			"vni": {
 				Type:        schema.TypeInt,

--- a/nsxt/resource_nsxt_logical_switch_test.go
+++ b/nsxt/resource_nsxt_logical_switch_test.go
@@ -26,7 +26,7 @@ func TestAccResourceNsxtLogicalSwitch_basic(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXLogicalSwitchCheckDestroy(state, switchName)
+			return testAccNSXLogicalSwitchCheckDestroy(state, switchName, "nsxt_logical_switch")
 		},
 		Steps: []resource.TestStep{
 			{
@@ -61,6 +61,7 @@ func TestAccResourceNsxtLogicalSwitch_basic(t *testing.T) {
 	})
 }
 
+// This use case is deprecated and should be removed with next major release
 func TestAccResourceNsxtLogicalSwitch_vlan(t *testing.T) {
 	switchName := "test-nsx-logical-switch-vlan"
 	updateSwitchName := fmt.Sprintf("%s-update", switchName)
@@ -71,19 +72,14 @@ func TestAccResourceNsxtLogicalSwitch_vlan(t *testing.T) {
 	origvlan := "1"
 	updatedvlan := "2"
 	replicationMode := ""
-	// TODO - add verification that replication mode can not be set for vlan LS
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXLogicalSwitchCheckDestroy(state, switchName)
+			return testAccNSXLogicalSwitchCheckDestroy(state, switchName, "nsxt_logical_switch")
 		},
 		Steps: []resource.TestStep{
-			{
-				Config:      testAccNSXLogicalSwitchNoVlanTemplate(switchName, transportZoneName),
-				ExpectError: regexp.MustCompile(`Error during LogicalSwitch create`),
-			},
 			{
 				Config: testAccNSXLogicalSwitchCreateTemplate(resourceName, switchName, transportZoneName, origvlan, replicationMode),
 				Check: resource.ComposeTestCheckFunc(
@@ -124,7 +120,7 @@ func TestAccResourceNsxtLogicalSwitch_withProfiles(t *testing.T) {
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			// Verify that the LS was deleted
-			err := testAccNSXLogicalSwitchCheckDestroy(state, switchName)
+			err := testAccNSXLogicalSwitchCheckDestroy(state, switchName, "nsxt_logical_switch")
 			if err != nil {
 				return err
 			}
@@ -179,7 +175,7 @@ func TestAccResourceNsxtLogicalSwitch_withMacPool(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXLogicalSwitchCheckDestroy(state, switchName)
+			return testAccNSXLogicalSwitchCheckDestroy(state, switchName, "nsxt_logical_switch")
 		},
 		Steps: []resource.TestStep{
 			{
@@ -214,7 +210,7 @@ func TestAccResourceNsxtLogicalSwitch_importBasic(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXLogicalSwitchCheckDestroy(state, switchName)
+			return testAccNSXLogicalSwitchCheckDestroy(state, switchName, "nsxt_logical_switch")
 		},
 		Steps: []resource.TestStep{
 			{
@@ -264,11 +260,11 @@ func testAccNSXLogicalSwitchExists(displayName string, resourceName string) reso
 	}
 }
 
-func testAccNSXLogicalSwitchCheckDestroy(state *terraform.State, displayName string) error {
+func testAccNSXLogicalSwitchCheckDestroy(state *terraform.State, resourceType string, displayName string) error {
 	nsxClient := testAccProvider.Meta().(*nsxt.APIClient)
 	for _, rs := range state.RootModule().Resources {
 
-		if rs.Type != "nsxt_logical_switch" {
+		if rs.Type != resourceType {
 			continue
 		}
 

--- a/nsxt/resource_nsxt_vlan_logical_switch.go
+++ b/nsxt/resource_nsxt_vlan_logical_switch.go
@@ -1,42 +1,23 @@
-/* Copyright © 2017 VMware, Inc. All Rights Reserved.
+/* Copyright © 2019 VMware, Inc. All Rights Reserved.
    SPDX-License-Identifier: MPL-2.0 */
 
 package nsxt
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/hashicorp/terraform/helper/validation"
 	api "github.com/vmware/go-vmware-nsxt"
 	"github.com/vmware/go-vmware-nsxt/manager"
 	"log"
 	"net/http"
-	"time"
 )
 
-var logicalSwitchReplicationModeValues = []string{"MTEP", "SOURCE", ""}
-
-// formatLogicalSwitchRollbackError defines the verbose error when
-// rollback fails on a logical switch creation.
-const formatLogicalSwitchRollbackError = `
-WARNING:
-There was an error during the creation of logical switch %s:
-%s
-Additionally, there was an error deleting the logical switch during rollback:
-%s
-The logical switch may still exist in the NSX. If it does, please manually delete it
-and try again.
-`
-
-// This resource represents overlay logical switch
-// Vlan logical switch is represented with separate resource
-func resourceNsxtLogicalSwitch() *schema.Resource {
+func resourceNsxtVlanLogicalSwitch() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceNsxtLogicalSwitchCreate,
-		Read:   resourceNsxtLogicalSwitchRead,
-		Update: resourceNsxtLogicalSwitchUpdate,
-		Delete: resourceNsxtLogicalSwitchDelete,
+		Create: resourceNsxtVlanLogicalSwitchCreate,
+		Read:   resourceNsxtVlanLogicalSwitchRead,
+		Update: resourceNsxtVlanLogicalSwitchUpdate,
+		Delete: resourceNsxtVlanLogicalSwitchDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -67,13 +48,6 @@ func resourceNsxtLogicalSwitch() *schema.Resource {
 				Description: "Mac pool id that associated with a LogicalSwitch",
 				Optional:    true,
 			},
-			"replication_mode": &schema.Schema{
-				Type:         schema.TypeString,
-				Description:  "Replication mode of the Logical Switch",
-				Optional:     true,
-				Default:      "MTEP",
-				ValidateFunc: validation.StringInSlice(logicalSwitchReplicationModeValues, false),
-			},
 			"switching_profile_id": getSwitchingProfileIdsSchema(),
 			"transport_zone_id": &schema.Schema{
 				Type:        schema.TypeString,
@@ -83,22 +57,15 @@ func resourceNsxtLogicalSwitch() *schema.Resource {
 			},
 			"vlan": &schema.Schema{
 				Type:        schema.TypeInt,
-				Description: "Vlan trunk spec",
-				Deprecated:  "Use nsxt_vlan_logical_switch resource instead",
-				Optional:    true,
+				Description: "VLAN Id or VLAN Trunk Spec",
+				Required:    true,
 			},
 			// TODO - add option for vlan trunk spec
-			"vni": &schema.Schema{
-				Type:        schema.TypeInt,
-				Description: "VNI for this LogicalSwitch",
-				Optional:    true,
-				Computed:    true,
-			},
 		},
 	}
 }
 
-func resourceNsxtLogicalSwitchCreate(d *schema.ResourceData, m interface{}) error {
+func resourceNsxtVlanLogicalSwitchCreate(d *schema.ResourceData, m interface{}) error {
 	nsxClient := m.(*api.APIClient)
 	description := d.Get("description").(string)
 	displayName := d.Get("display_name").(string)
@@ -107,11 +74,9 @@ func resourceNsxtLogicalSwitchCreate(d *schema.ResourceData, m interface{}) erro
 	adminState := d.Get("admin_state").(string)
 	ipPoolID := d.Get("ip_pool_id").(string)
 	macPoolID := d.Get("mac_pool_id").(string)
-	replicationMode := d.Get("replication_mode").(string)
 	switchingProfileID := getSwitchingProfileIdsFromSchema(d)
 	transportZoneID := d.Get("transport_zone_id").(string)
 	vlan := int64(d.Get("vlan").(int))
-	vni := int32(d.Get("vni").(int))
 
 	logicalSwitch := manager.LogicalSwitch{
 		Description:         description,
@@ -121,11 +86,9 @@ func resourceNsxtLogicalSwitchCreate(d *schema.ResourceData, m interface{}) erro
 		AdminState:          adminState,
 		IpPoolId:            ipPoolID,
 		MacPoolId:           macPoolID,
-		ReplicationMode:     replicationMode,
 		SwitchingProfileIds: switchingProfileID,
 		TransportZoneId:     transportZoneID,
 		Vlan:                vlan,
-		Vni:                 vni,
 	}
 
 	logicalSwitch, resp, err := nsxClient.LogicalSwitchingApi.CreateLogicalSwitch(nsxClient.Context, logicalSwitch)
@@ -138,54 +101,18 @@ func resourceNsxtLogicalSwitchCreate(d *schema.ResourceData, m interface{}) erro
 		return fmt.Errorf("Unexpected status returned during LogicalSwitch create: %v", resp.StatusCode)
 	}
 
-	d.SetId(logicalSwitch.Id)
+	err = resourceNsxtLogicalSwitchVerifyRealization(d, nsxClient, &logicalSwitch)
 
-	return resourceNsxtLogicalSwitchRead(d, m)
-}
-
-func resourceNsxtLogicalSwitchVerifyRealization(d *schema.ResourceData, nsxClient *api.APIClient, logicalSwitch *manager.LogicalSwitch) error {
-	// verifying switch realization on hypervisor
-	stateConf := &resource.StateChangeConf{
-		Pending: []string{"in_progress", "pending", "partial_success"},
-		Target:  []string{"success"},
-		Refresh: func() (interface{}, string, error) {
-			state, resp, err := nsxClient.LogicalSwitchingApi.GetLogicalSwitchState(nsxClient.Context, logicalSwitch.Id)
-			if err != nil {
-				return nil, "", fmt.Errorf("Error while querying realization state: %v", err)
-			}
-
-			if resp.StatusCode != http.StatusOK {
-				return nil, "", fmt.Errorf("Unexpected return status %d", resp.StatusCode)
-			}
-
-			if state.FailureCode != 0 {
-				return nil, "", fmt.Errorf("Error in switch realization: %s", state.FailureMessage)
-			}
-
-			log.Printf("[DEBUG] Realization state: %s", state.State)
-			return logicalSwitch, state.State, nil
-		},
-		Timeout:    d.Timeout(schema.TimeoutCreate),
-		MinTimeout: 1 * time.Second,
-		Delay:      1 * time.Second,
-	}
-	_, err := stateConf.WaitForState()
 	if err != nil {
-		// Realization failed - rollback & delete the switch
-		log.Printf("[ERROR] Rollback switch %s creation due to unrealized state", logicalSwitch.Id)
-		localVarOptionals := make(map[string]interface{})
-		_, derr := nsxClient.LogicalSwitchingApi.DeleteLogicalSwitch(nsxClient.Context, logicalSwitch.Id, localVarOptionals)
-		if derr != nil {
-			// rollback failed
-			return fmt.Errorf(formatLogicalSwitchRollbackError, logicalSwitch.Id, err, derr)
-		}
 		return err
 	}
 
-	return nil
+	d.SetId(logicalSwitch.Id)
+
+	return resourceNsxtVlanLogicalSwitchRead(d, m)
 }
 
-func resourceNsxtLogicalSwitchRead(d *schema.ResourceData, m interface{}) error {
+func resourceNsxtVlanLogicalSwitchRead(d *schema.ResourceData, m interface{}) error {
 	nsxClient := m.(*api.APIClient)
 	id := d.Id()
 	if id == "" {
@@ -202,12 +129,6 @@ func resourceNsxtLogicalSwitchRead(d *schema.ResourceData, m interface{}) error 
 		return nil
 	}
 
-	err = resourceNsxtLogicalSwitchVerifyRealization(d, nsxClient, &logicalSwitch)
-
-	if err != nil {
-		return err
-	}
-
 	d.Set("revision", logicalSwitch.Revision)
 	d.Set("description", logicalSwitch.Description)
 	d.Set("display_name", logicalSwitch.DisplayName)
@@ -219,19 +140,17 @@ func resourceNsxtLogicalSwitchRead(d *schema.ResourceData, m interface{}) error 
 	d.Set("admin_state", logicalSwitch.AdminState)
 	d.Set("ip_pool_id", logicalSwitch.IpPoolId)
 	d.Set("mac_pool_id", logicalSwitch.MacPoolId)
-	d.Set("replication_mode", logicalSwitch.ReplicationMode)
 	err = setSwitchingProfileIdsInSchema(d, nsxClient, logicalSwitch.SwitchingProfileIds)
 	if err != nil {
 		return fmt.Errorf("Error during logical switch profiles set in schema: %v", err)
 	}
 	d.Set("transport_zone_id", logicalSwitch.TransportZoneId)
 	d.Set("vlan", logicalSwitch.Vlan)
-	d.Set("vni", logicalSwitch.Vni)
 
 	return nil
 }
 
-func resourceNsxtLogicalSwitchUpdate(d *schema.ResourceData, m interface{}) error {
+func resourceNsxtVlanLogicalSwitchUpdate(d *schema.ResourceData, m interface{}) error {
 	nsxClient := m.(*api.APIClient)
 	id := d.Id()
 	if id == "" {
@@ -245,11 +164,9 @@ func resourceNsxtLogicalSwitchUpdate(d *schema.ResourceData, m interface{}) erro
 	adminState := d.Get("admin_state").(string)
 	ipPoolID := d.Get("ip_pool_id").(string)
 	macPoolID := d.Get("mac_pool_id").(string)
-	replicationMode := d.Get("replication_mode").(string)
 	switchingProfileID := getSwitchingProfileIdsFromSchema(d)
 	transportZoneID := d.Get("transport_zone_id").(string)
 	vlan := int64(d.Get("vlan").(int))
-	vni := int32(d.Get("vni").(int))
 	revision := int64(d.Get("revision").(int))
 	logicalSwitch := manager.LogicalSwitch{
 		Description:         description,
@@ -259,11 +176,9 @@ func resourceNsxtLogicalSwitchUpdate(d *schema.ResourceData, m interface{}) erro
 		AdminState:          adminState,
 		IpPoolId:            ipPoolID,
 		MacPoolId:           macPoolID,
-		ReplicationMode:     replicationMode,
 		SwitchingProfileIds: switchingProfileID,
 		TransportZoneId:     transportZoneID,
 		Vlan:                vlan,
-		Vni:                 vni,
 		Revision:            revision,
 	}
 
@@ -272,10 +187,10 @@ func resourceNsxtLogicalSwitchUpdate(d *schema.ResourceData, m interface{}) erro
 		return fmt.Errorf("Error during LogicalSwitch update: %v", err)
 	}
 
-	return resourceNsxtLogicalSwitchRead(d, m)
+	return resourceNsxtVlanLogicalSwitchRead(d, m)
 }
 
-func resourceNsxtLogicalSwitchDelete(d *schema.ResourceData, m interface{}) error {
+func resourceNsxtVlanLogicalSwitchDelete(d *schema.ResourceData, m interface{}) error {
 	nsxClient := m.(*api.APIClient)
 	id := d.Id()
 	if id == "" {

--- a/nsxt/resource_nsxt_vlan_logical_switch.go
+++ b/nsxt/resource_nsxt_vlan_logical_switch.go
@@ -57,7 +57,7 @@ func resourceNsxtVlanLogicalSwitch() *schema.Resource {
 			},
 			"vlan": &schema.Schema{
 				Type:        schema.TypeInt,
-				Description: "VLAN Id or VLAN Trunk Spec",
+				Description: "VLAN Id",
 				Required:    true,
 			},
 			// TODO - add option for vlan trunk spec

--- a/nsxt/resource_nsxt_vlan_logical_switch_test.go
+++ b/nsxt/resource_nsxt_vlan_logical_switch_test.go
@@ -1,0 +1,319 @@
+/* Copyright © 2017 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"regexp"
+	"testing"
+)
+
+func TestAccResourceNsxtVlanLogicalSwitch_basic(t *testing.T) {
+	switchName := "test-nsx-logical-switch-vlan"
+	updateSwitchName := fmt.Sprintf("%s-update", switchName)
+	transportZoneName := getVlanTransportZoneName()
+	resourceName := "testvlan"
+	testResourceName := fmt.Sprintf("nsxt_vlan_logical_switch.%s", resourceName)
+
+	origvlan := "1"
+	updatedvlan := "2"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNSXLogicalSwitchCheckDestroy(state, switchName, "nsxt_vlan_logical_switch")
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNSXVlanLogicalSwitchCreateTemplate(resourceName, switchName, transportZoneName, origvlan),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNSXLogicalSwitchExists(switchName, testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", switchName),
+					resource.TestCheckResourceAttr(testResourceName, "description", "Acceptance Test"),
+					resource.TestCheckResourceAttr(testResourceName, "admin_state", "UP"),
+					resource.TestCheckResourceAttr(testResourceName, "vlan", origvlan),
+				),
+			},
+			{
+				Config: testAccNSXVlanLogicalSwitchUpdateTemplate(resourceName, updateSwitchName, transportZoneName, updatedvlan),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNSXLogicalSwitchExists(updateSwitchName, testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", updateSwitchName),
+					resource.TestCheckResourceAttr(testResourceName, "description", "Acceptance Test Update"),
+					resource.TestCheckResourceAttr(testResourceName, "admin_state", "DOWN"),
+					resource.TestCheckResourceAttr(testResourceName, "vlan", updatedvlan),
+				),
+			},
+		},
+	})
+
+}
+
+func TestAccResourceNsxtVlanLogicalSwitch_withProfiles(t *testing.T) {
+	switchName := fmt.Sprintf("test-nsx-logical-switch-with-profiles")
+	updateSwitchName := fmt.Sprintf("%s-update", switchName)
+	resourceName := "test_profiles"
+	testResourceName := fmt.Sprintf("nsxt_vlan_logical_switch.%s", resourceName)
+	transportZoneName := getVlanTransportZoneName()
+	customProfileName := "terraform_test_LS_profile"
+	oobProfileName := "nsx-default-switch-security-vif-profile"
+	profileType := "SwitchSecuritySwitchingProfile"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			// Verify that the LS was deleted
+			err := testAccNSXLogicalSwitchCheckDestroy(state, switchName, "nsxt_vlan_logical_switch")
+			if err != nil {
+				return err
+			}
+			// Delete the created switching profile
+			return testAccDataSourceNsxtSwitchingProfileDeleteByName(customProfileName)
+		},
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					// Create a custom switching profile
+					if err := testAccDataSourceNsxtSwitchingProfileCreate(customProfileName, profileType); err != nil {
+						panic(err)
+					}
+				},
+				// Create a logical switch to use the custom switching profile
+				Config: testAccNSXVlanLogicalSwitchCreateWithProfilesTemplate(resourceName, switchName, transportZoneName, customProfileName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNSXLogicalSwitchExists(switchName, testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", switchName),
+					resource.TestCheckResourceAttr(testResourceName, "switching_profile_id.#", "1"),
+				),
+			},
+			{
+				// Replace the custom switching profile with OOB one
+				Config:             testAccNSXVlanLogicalSwitchUpdateWithProfilesTemplate(resourceName, updateSwitchName, transportZoneName, customProfileName, oobProfileName),
+				ExpectNonEmptyPlan: true,
+				Check: resource.ComposeTestCheckFunc(
+					testAccNSXLogicalSwitchExists(updateSwitchName, testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", updateSwitchName),
+					// Counting only custom profiles so count should be 0
+					resource.TestCheckResourceAttr(testResourceName, "switching_profile_id.#", "0"),
+				),
+			},
+			{
+				// remove the data source for the custom switching profile
+				Config: testAccNSXSwitchingNoProfileTemplate(),
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtVlanLogicalSwitch_withMacPool(t *testing.T) {
+	switchName := fmt.Sprintf("test-nsx-logical-switch-with-mac")
+	resourceName := "test_mac_pool"
+	testResourceName := fmt.Sprintf("nsxt_vlan_logical_switch.%s", resourceName)
+	transportZoneName := getVlanTransportZoneName()
+	macPoolName := getMacPoolName()
+	novlan := "0"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNSXLogicalSwitchCheckDestroy(state, switchName, "nsxt_vlan_logical_switch")
+		},
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccNSXLogicalSwitchNoTZIDTemplate(switchName),
+				ExpectError: regexp.MustCompile(`required field is not set`),
+			},
+			{
+				Config: testAccNSXVlanLogicalSwitchCreateWithMacTemplate(resourceName, switchName, transportZoneName, macPoolName, novlan),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNSXLogicalSwitchExists(switchName, testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", switchName),
+					resource.TestCheckResourceAttr(testResourceName, "description", "Acceptance Test"),
+					resource.TestCheckResourceAttr(testResourceName, "admin_state", "UP"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "vlan", novlan),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtVlanLogicalSwitch_importBasic(t *testing.T) {
+	switchName := fmt.Sprintf("test-nsx-logical-switch")
+	resourceName := "test"
+	testResourceName := fmt.Sprintf("nsxt_vlan_logical_switch.%s", resourceName)
+	vlan := "5"
+	transportZoneName := getVlanTransportZoneName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNSXLogicalSwitchCheckDestroy(state, switchName, "nsxt_vlan_logical_switch")
+		},
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccNSXLogicalSwitchNoTZIDTemplate(switchName),
+				ExpectError: regexp.MustCompile(`required field is not set`),
+			},
+			{
+				Config: testAccNSXVlanLogicalSwitchCreateTemplate(resourceName, switchName, transportZoneName, vlan),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccNSXVlanLogicalSwitchNoTZIDTemplate(switchName string) string {
+	return fmt.Sprintf(`
+resource "nsxt_vlan_logical_switch" "error" {
+  display_name     = "%s"
+  admin_state      = "UP"
+  description      = "Acceptance Test"
+}`, switchName)
+}
+
+func testAccNSXVlanLogicalSwitchNoVlanTemplate(switchName string, transportZoneName string) string {
+	return fmt.Sprintf(`
+data "nsxt_transport_zone" "TZ1" {
+  display_name = "%s"
+}
+
+resource "nsxt_vlan_logical_switch" "error" {
+  display_name      = "%s"
+  admin_state       = "UP"
+  description       = "Acceptance Test"
+  transport_zone_id = "${data.nsxt_transport_zone.TZ1.id}"
+}`, transportZoneName, switchName)
+}
+
+func testAccNSXVlanLogicalSwitchCreateTemplate(resourceName string, switchName string, transportZoneName string, vlan string) string {
+	return fmt.Sprintf(`
+data "nsxt_transport_zone" "TZ1" {
+  display_name = "%s"
+}
+
+resource "nsxt_vlan_logical_switch" "%s" {
+  display_name      = "%s"
+  admin_state       = "UP"
+  description       = "Acceptance Test"
+  transport_zone_id = "${data.nsxt_transport_zone.TZ1.id}"
+  vlan              = "%s"
+
+  tag {
+    scope = "scope1"
+    tag   = "tag1"
+  }
+}`, transportZoneName, resourceName, switchName, vlan)
+}
+
+func testAccNSXVlanLogicalSwitchUpdateTemplate(resourceName string, switchUpdateName string, transportZoneName string, vlan string) string {
+	return fmt.Sprintf(`
+data "nsxt_transport_zone" "TZ1" {
+  display_name = "%s"
+}
+
+resource "nsxt_vlan_logical_switch" "%s" {
+  display_name      = "%s"
+  admin_state       = "DOWN"
+  description       = "Acceptance Test Update"
+  transport_zone_id = "${data.nsxt_transport_zone.TZ1.id}"
+  vlan              = "%s"
+
+  tag {
+    scope = "scope1"
+    tag   = "tag1"
+  }
+
+  tag {
+    scope = "scope2"
+    tag   = "tag2"
+  }
+}`, transportZoneName, resourceName, switchUpdateName, vlan)
+}
+
+func testAccNSXVlanLogicalSwitchCreateWithProfilesTemplate(resourceName string, switchName string, transportZoneName string, profileName string) string {
+	return fmt.Sprintf(`
+data "nsxt_transport_zone" "TZ1" {
+  display_name = "%s"
+}
+
+data "nsxt_switching_profile" "test1" {
+  display_name = "%s"
+}
+
+resource "nsxt_vlan_logical_switch" "%s" {
+  display_name      = "%s"
+  admin_state       = "UP"
+  transport_zone_id = "${data.nsxt_transport_zone.TZ1.id}"
+  vlan              = 1
+
+  switching_profile_id {
+    key   = "${data.nsxt_switching_profile.test1.resource_type}"
+    value = "${data.nsxt_switching_profile.test1.id}"
+  }
+}`, transportZoneName, profileName, resourceName, switchName)
+}
+
+func testAccNSXVlanLogicalSwitchUpdateWithProfilesTemplate(resourceName string, switchUpdateName string, transportZoneName string, profileName1 string, profileName2 string) string {
+	return fmt.Sprintf(`
+data "nsxt_transport_zone" "TZ1" {
+  display_name = "%s"
+}
+
+data "nsxt_switching_profile" "test1" {
+  display_name = "%s"
+}
+
+data "nsxt_switching_profile" "test2" {
+  display_name = "%s"
+}
+
+resource "nsxt_vlan_logical_switch" "%s" {
+  display_name      = "%s"
+  admin_state       = "UP"
+  transport_zone_id = "${data.nsxt_transport_zone.TZ1.id}"
+  vlan              = 1
+
+  switching_profile_id {
+    key   = "${data.nsxt_switching_profile.test2.resource_type}"
+    value = "${data.nsxt_switching_profile.test2.id}"
+  }
+
+}`, transportZoneName, profileName1, profileName2, resourceName, switchUpdateName)
+}
+
+func testAccNSXVlanLogicalSwitchCreateWithMacTemplate(resourceName string, switchName string, transportZoneName string, macPoolName string, vlan string) string {
+	return fmt.Sprintf(`
+data "nsxt_transport_zone" "TZ1" {
+  display_name = "%s"
+}
+
+data "nsxt_mac_pool" "MAC1" {
+  display_name = "%s"
+}
+
+resource "nsxt_vlan_logical_switch" "%s" {
+  display_name      = "%s"
+  admin_state       = "UP"
+  description       = "Acceptance Test"
+  transport_zone_id = "${data.nsxt_transport_zone.TZ1.id}"
+  vlan              = "%s"
+  mac_pool_id       = "${data.nsxt_mac_pool.MAC1.id}"
+
+  tag {
+    scope = "scope1"
+    tag   = "tag1"
+  }
+}`, transportZoneName, macPoolName, resourceName, switchName, vlan)
+}

--- a/vendor/github.com/vmware/go-vmware-nsxt/manager/logical_switch.go
+++ b/vendor/github.com/vmware/go-vmware-nsxt/manager/logical_switch.go
@@ -71,7 +71,7 @@ type LogicalSwitch struct {
 	// Id of the TransportZone to which this LogicalSwitch is associated
 	TransportZoneId string `json:"transport_zone_id"`
 
-	Vlan int64 `json:"vlan,omitempty"`
+	Vlan int64 `json:"vlan"`
 
 	// VNI for this LogicalSwitch.
 	Vni int32 `json:"vni,omitempty"`

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -2332,10 +2332,10 @@
 			"revisionTime": "2018-10-02T18:05:17Z"
 		},
 		{
-			"checksumSHA1": "1Aq+4XzgRMdTxNGn5LE+8xIw8ic=",
+			"checksumSHA1": "50uXvx4CdRp5+stghmHHGNFzU3I=",
 			"path": "github.com/vmware/go-vmware-nsxt/manager",
-			"revision": "5e48fa05cb919c40b39d6ab5b301d0123fa16c5d",
-			"revisionTime": "2018-09-14T00:15:15Z"
+			"revision": "392fff3788ca313f64ba62d7a2d88e84cc372da2",
+			"revisionTime": "2019-01-31T01:31:15Z"
 		},
 		{
 			"checksumSHA1": "NVOWbWEQajRsbUIEwdoTyDP80AM=",

--- a/website/docs/r/logical_switch.html.markdown
+++ b/website/docs/r/logical_switch.html.markdown
@@ -2,12 +2,12 @@
 layout: "nsxt"
 page_title: "NSXT: nsxt_logical_switch"
 sidebar_current: "docs-nsxt-resource-logical-switch"
-description: A resource to configure a logical switch in NSX.
+description: A resource to configure overlay logical switch in NSX.
 ---
 
 # nsxt_logical_switch
 
-This resource provides a method to create a logical switch in NSX. Virtual machines can then be connected to the appropriate logical switch for the desired topology and network connectivity.
+This resource provides a method to create overlay logical switch in NSX. Virtual machines can then be connected to the appropriate logical switch for the desired topology and network connectivity.
 
 ## Example Usage
 
@@ -43,8 +43,8 @@ The following arguments are supported:
 * `description` - (Optional) Description of the resource.
 * `ip_pool_id` - (Optional) Ip Pool ID to be associated with the logical switch.
 * `mac_pool_id` - (Optional) Mac Pool ID to be associated with the logical switch.
-* `vlan` - (Optional) Vlan for vlan logical switch. If not specified, this switch is overlay logical switch.
-* `vni` - (Optional) Vni for the logical switch.
+* `vlan` - (Deprecated, Optional) Vlan for vlan logical switch. This attribute is deprecated, please use nsxt_vlan_logical_switch resource to manage vlan logical switches.
+* `vni` - (Optional, Readonly) Vni for the logical switch.
 * `address_binding` - (Optional) List of Address Bindings for the logical switch. This setting allows to provide bindings between IP address, mac Address and vlan.
 * `tag` - (Optional) A list of scope + tag pairs to associate with this logical switch.
 

--- a/website/docs/r/vlan_logical_switch.html.markdown
+++ b/website/docs/r/vlan_logical_switch.html.markdown
@@ -1,0 +1,66 @@
+---
+layout: "nsxt"
+page_title: "NSXT: nsxt_logical_switch"
+sidebar_current: "docs-nsxt-resource-logical-switch"
+description: A resource to configure vlan logical switch in NSX.
+---
+
+# nsxt_vlan_logical_switch
+
+This resource provides a method to create vlan logical switch in NSX. Virtual machines can then be connected to the appropriate logical switch for the desired topology and network connectivity.
+
+## Example Usage
+
+```hcl
+resource "nsxt_logical_switch" "switch1" {
+  admin_state       = "UP"
+  description       = "LS1 provisioned by Terraform"
+  display_name      = "LS1"
+  transport_zone_id = "${data.nsxt_transport_zone.vlan_transport_zone.id}"
+  vlan              = 2
+
+  tag {
+    scope = "color"
+    tag   = "blue"
+  }
+
+  switching_profile_id {
+    key   = "${data.nsxt_switching_profile.qos_profiles.resource_type}"
+    value = "${data.nsxt_switching_profile.qos_profiles.id}"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `transport_zone_id` - (Required) Transport Zone ID for the logical switch.
+* `admin_state` - (Optional) Admin state for the logical switch. Accepted values - 'UP' or 'DOWN'. The default value is 'UP'.
+* `vlan` - (Required) Vlan for the logical switch.
+* `switching_profile_id` - (Optional) List of IDs of switching profiles (of various types) to be associated with this switch. Default switching profiles will be used if not specified.
+* `display_name` - (Optional) Display name, defaults to ID if not set.
+* `description` - (Optional) Description of the resource.
+* `ip_pool_id` - (Optional) Ip Pool ID to be associated with the logical switch.
+* `mac_pool_id` - (Optional) Mac Pool ID to be associated with the logical switch.
+* `address_binding` - (Optional) List of Address Bindings for the logical switch. This setting allows to provide bindings between IP address, mac Address and vlan.
+* `tag` - (Optional) A list of scope + tag pairs to associate with this logical switch.
+
+## Attributes Reference
+
+In addition to arguments listed above, the following attributes are exported:
+
+* `id` - ID of the logical switch.
+* `revision` - Indicates current revision number of the object as seen by NSX-T API server. This attribute can be useful for debugging.
+
+## Importing
+
+An existing X can be [imported][docs-import] into this resource, via the following command:
+
+[docs-import]: /docs/import/index.html
+
+```
+terraform import nsxt_logical_switch.switch1 UUID
+```
+
+The above command imports the logical switch named `switch1` with the NSX id `UUID`.

--- a/website/nsxt.erb
+++ b/website/nsxt.erb
@@ -142,6 +142,9 @@
                         <li<%= sidebar_current("docs-nsxt-resource-logical-switch") %>>
                             <a href="/docs/providers/nsxt/r/logical_switch.html">nsxt_logical_switch</a>
                         </li>
+                        <li<%= sidebar_current("docs-nsxt-resource-vlan-logical-switch") %>>
+                            <a href="/docs/providers/nsxt/r/vlan_logical_switch.html">nsxt_vlan_logical_switch</a>
+                        </li>
                         <li<%= sidebar_current("docs-nsxt-resource-logical-tier0-router") %>>
                             <a href="/docs/providers/nsxt/r/logical_tier0_router.html">nsxt_logical_tier0_router</a>
                         </li>


### PR DESCRIPTION
This way default/required attributes are easier to manage and
understand.

In addition, allow zero value for vlan.