### PR TITLE
Add remote_auth option for vIDM case

### DIFF
--- a/nsxt/provider.go
+++ b/nsxt/provider.go
@@ -33,6 +33,11 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("NSXT_PASSWORD", nil),
 				Sensitive:   true,
 			},
+			"remote_auth": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("NSXT_REMOTE_AUTH", false),
+			},
 			"host": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -181,6 +186,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	insecure := d.Get("allow_unverified_ssl").(bool)
 	username := d.Get("username").(string)
 	password := d.Get("password").(string)
+	remoteAuth := d.Get("remote_auth").(bool)
 
 	if needCreds {
 		if username == "" {
@@ -230,6 +236,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		UserAgent:            "terraform-provider-nsxt/1.0",
 		UserName:             username,
 		Password:             password,
+		RemoteAuth:           remoteAuth,
 		ClientAuthCertFile:   clientAuthCertFile,
 		ClientAuthKeyFile:    clientAuthKeyFile,
 		CAFile:               caFile,

--- a/nsxt/provider_test.go
+++ b/nsxt/provider_test.go
@@ -57,13 +57,14 @@ func testAccGetClient() (*api.APIClient, error) {
 	}
 
 	cfg := api.Configuration{
-		BasePath:  "/api/v1",
-		Host:      os.Getenv("NSXT_MANAGER_HOST"),
-		Scheme:    "https",
-		UserAgent: "terraform-provider-nsxt/1.0",
-		UserName:  os.Getenv("NSXT_USERNAME"),
-		Password:  os.Getenv("NSXT_PASSWORD"),
-		Insecure:  insecure,
+		BasePath:   "/api/v1",
+		Host:       os.Getenv("NSXT_MANAGER_HOST"),
+		Scheme:     "https",
+		UserAgent:  "terraform-provider-nsxt/1.0",
+		UserName:   os.Getenv("NSXT_USERNAME"),
+		Password:   os.Getenv("NSXT_PASSWORD"),
+		RemoteAuth: false,
+		Insecure:   insecure,
 	}
 
 	return api.NewAPIClient(&cfg)

--- a/nsxt/resource_nsxt_algorithm_type_ns_service_test.go
+++ b/nsxt/resource_nsxt_algorithm_type_ns_service_test.go
@@ -107,6 +107,9 @@ func testAccNSXAlgServiceExists(displayName string, resourceName string) resourc
 
 func testAccNSXAlgServiceCheckDestroy(state *terraform.State, displayName string) error {
 	nsxClient := testAccProvider.Meta().(*nsxt.APIClient)
+	if nsxClient == nil {
+		return fmt.Errorf("Failed to initialize the client")
+	}
 	for _, rs := range state.RootModule().Resources {
 
 		if rs.Type != "nsxt_algorithm_type_ns_service" {

--- a/vendor/github.com/vmware/go-vmware-nsxt/configuration.go
+++ b/vendor/github.com/vmware/go-vmware-nsxt/configuration.go
@@ -37,6 +37,7 @@ type Configuration struct {
 	Scheme               string `json:"scheme,omitempty"`
 	UserName             string
 	Password             string
+	RemoteAuth           bool
 	DefaultHeader        map[string]string `json:"defaultHeader,omitempty"`
 	UserAgent            string            `json:"userAgent,omitempty"`
 	ClientAuthCertFile   string

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -2266,10 +2266,10 @@
 			"revisionTime": "2017-06-05T21:53:11Z"
 		},
 		{
-			"checksumSHA1": "Hm9rzsXgLTMV1554JI0vcOi0sDc=",
+			"checksumSHA1": "6Q5+n9zxU1WadwSyUuYIe1UEDao=",
 			"path": "github.com/vmware/go-vmware-nsxt",
-			"revision": "59800fc252baf7d25de64ba7524c1e5ba9c987c7",
-			"revisionTime": "2018-11-24T00:22:06Z"
+			"revision": "16aa0443042dfa6fe93e69bad05b8053cde7e2f7",
+			"revisionTime": "2019-02-01T20:55:56Z"
 		},
 		{
 			"checksumSHA1": "o0gNsuAZWWIs1RY7hh5cB5j85q4=",

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -147,8 +147,9 @@ The following arguments are used to configure the VMware NSX-T Provider:
   essentially retrying on throttled connections. Can also be specified with the
   `NSXT_RETRY_ON_STATUS_CODES` environment variable.
 * `remote_auth` - (Optional) Would trigger remote authorization instead of basic
-  authorization. This is useful for vIDM authorization use case. Default: false.
-  Can also be specified with the `NSXT_REMOTE_AUTH` environment variable.
+  authorization. This is required for users based on vIDM authentication.
+  The default for this flag is false. Can also be specified with the
+  `NSXT_REMOTE_AUTH` environment variable.
 
 ## NSX Logical Networking
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -146,6 +146,9 @@ The following arguments are used to configure the VMware NSX-T Provider:
   By default, the provider will retry on HTTP error 429 (too many requests),
   essentially retrying on throttled connections. Can also be specified with the
   `NSXT_RETRY_ON_STATUS_CODES` environment variable.
+* `remote_auth` - (Optional) Would trigger remote authorization instead of basic
+  authorization. This is useful for vIDM authorization use case. Default: false.
+  Can also be specified with the `NSXT_REMOTE_AUTH` environment variable.
 
 ## NSX Logical Networking
 


### PR DESCRIPTION
Setting remote_auth flag to true in provider will triger remote
authorization (Remote keyword in Authorization header). The default
for the flag is false.