### PR TITLE
Mark edge_cluster_id as ForceNew in T1 router

### DIFF
--- a/nsxt/resource_nsxt_logical_tier1_router.go
+++ b/nsxt/resource_nsxt_logical_tier1_router.go
@@ -64,7 +64,10 @@ func resourceNsxtLogicalTier1Router() *schema.Resource {
 			"edge_cluster_id": {
 				Type:        schema.TypeString,
 				Description: "Edge Cluster Id",
-				Optional:    true,
+				// This is needed since updating edge cluster requires special handling
+				// which is not yet available in sdk
+				ForceNew: true,
+				Optional: true,
 			},
 			"enable_router_advertisement": {
 				Type:        schema.TypeBool,


### PR DESCRIPTION
Backend does not allow changing edge cluster with single update call,
we would need to disable firewall first, then dissassociate the cluster
and associate the new one. Until this is implemented, use ForceNew as
workaround.
This seems to trigger a mismatch bug on terraform apply, but the bug
goes away if we apply again. Will open the bug upstream.