### PR TITLE
Skip certain tests for old platform

### DIFF
--- a/nsxt/resource_nsxt_lb_client_ssl_profile_test.go
+++ b/nsxt/resource_nsxt_lb_client_ssl_profile_test.go
@@ -18,7 +18,7 @@ func TestAccResourceNsxtLbClientSSLProfile_basic(t *testing.T) {
 	testResourceName := "nsxt_lb_client_ssl_profile.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbClientSSLProfileCheckDestroy(state, name)
@@ -62,7 +62,7 @@ func TestAccResourceNsxtLbClientSSLProfile_importBasic(t *testing.T) {
 	name := "test"
 	testResourceName := "nsxt_lb_client_ssl_profile.test"
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbClientSSLProfileCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_lb_cookie_persistence_profile_test.go
+++ b/nsxt/resource_nsxt_lb_cookie_persistence_profile_test.go
@@ -22,7 +22,7 @@ func TestAccResourceNsxtLbCookiePersistenceProfile_basic(t *testing.T) {
 	updatedCookieName := "new_cookie"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbCookiePersistenceProfileCheckDestroy(state, name)
@@ -72,7 +72,7 @@ func TestAccResourceNsxtLbCookiePersistenceProfile_insertMode(t *testing.T) {
 	updatedCookiePath := "/subfolder1"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbCookiePersistenceProfileCheckDestroy(state, name)
@@ -126,7 +126,7 @@ func TestAccResourceNsxtLbCookiePersistenceProfile_importBasic(t *testing.T) {
 	name := "test-nsx-persistence-profile"
 	testResourceName := "nsxt_lb_cookie_persistence_profile.test"
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbCookiePersistenceProfileCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_lb_fast_tcp_application_profile_test.go
+++ b/nsxt/resource_nsxt_lb_fast_tcp_application_profile_test.go
@@ -24,7 +24,7 @@ func TestAccResourceNsxtLbFastTCPApplicationProfile_basic(t *testing.T) {
 	updatedMirroring := "false"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbFastTCPApplicationProfileCheckDestroy(state, name)
@@ -61,7 +61,7 @@ func TestAccResourceNsxtLbFastTCPApplicationProfile_importBasic(t *testing.T) {
 	name := "test-nsx-application-profile"
 	testResourceName := "nsxt_lb_fast_tcp_application_profile.test"
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbFastTCPApplicationProfileCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_lb_fast_udp_application_profile_test.go
+++ b/nsxt/resource_nsxt_lb_fast_udp_application_profile_test.go
@@ -22,7 +22,7 @@ func TestAccResourceNsxtLbFastUDPApplicationProfile_basic(t *testing.T) {
 	updatedMirroring := "false"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbFastUDPApplicationProfileCheckDestroy(state, name)
@@ -57,7 +57,7 @@ func TestAccResourceNsxtLbFastUDPApplicationProfile_importBasic(t *testing.T) {
 	name := "test-nsx-application-profile"
 	testResourceName := "nsxt_lb_fast_udp_application_profile.test"
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbFastUDPApplicationProfileCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_lb_http_application_profile_test.go
+++ b/nsxt/resource_nsxt_lb_http_application_profile_test.go
@@ -35,7 +35,7 @@ func TestAccResourceNsxtLbHTTPApplicationProfile_basic(t *testing.T) {
 	upNtlm := "false"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbHTTPApplicationProfileCheckDestroy(state, name)
@@ -75,7 +75,7 @@ func TestAccResourceNsxtLbHTTPApplicationProfile_importBasic(t *testing.T) {
 	name := "test"
 	testResourceName := "nsxt_lb_http_application_profile.test"
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbHTTPApplicationProfileCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_lb_http_forwarding_rule_test.go
+++ b/nsxt/resource_nsxt_lb_http_forwarding_rule_test.go
@@ -21,7 +21,7 @@ func TestAccResourceNsxtLbHttpForwardingRule_basic(t *testing.T) {
 	updatedMatchType := "ENDS_WITH"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbHTTPForwardingRuleCheckDestroy(state, name)
@@ -147,7 +147,7 @@ func TestAccResourceNsxtLbHttpForwardingRule_importBasic(t *testing.T) {
 	name := "test"
 	resourceName := "nsxt_lb_http_forwarding_rule.test"
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbHTTPForwardingRuleCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_lb_http_virtual_server_test.go
+++ b/nsxt/resource_nsxt_lb_http_virtual_server_test.go
@@ -25,7 +25,7 @@ func TestAccResourceNsxtLbHttpVirtualServer_basic(t *testing.T) {
 	updatedEnabled := "false"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbHTTPVirtualServerCheckDestroy(state, name)
@@ -82,7 +82,7 @@ func TestAccResourceNsxtLbHttpVirtualServer_withRules(t *testing.T) {
 	updatedRule2 := "rule1"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbHTTPVirtualServerCheckDestroy(state, name)
@@ -117,7 +117,7 @@ func TestAccResourceNsxtLbHttpVirtualServer_withSSL(t *testing.T) {
 	updatedDepth := "4"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			testAccNSXDeleteCerts(t, testLbVirtualServerCertID, testLbVirtualServerClientCertID, testLbVirtualServerCaCertID)
@@ -188,7 +188,7 @@ func TestAccResourceNsxtLbHttpVirtualServer_importBasic(t *testing.T) {
 	name := "test"
 	resourceName := "nsxt_lb_http_virtual_server.test"
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbHTTPVirtualServerCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_lb_icmp_monitor_test.go
+++ b/nsxt/resource_nsxt_lb_icmp_monitor_test.go
@@ -25,7 +25,7 @@ func TestAccResourceNsxtLbIcmpMonitor_basic(t *testing.T) {
 	updatedCount := "5"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbIcmpMonitorCheckDestroy(state, name)
@@ -69,7 +69,7 @@ func TestAccResourceNsxtLbIcmpMonitor_importBasic(t *testing.T) {
 	name := "test-nsx-monitor"
 	testResourceName := "nsxt_lb_icmp_monitor.test"
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbIcmpMonitorCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_lb_l4_monitor_test.go
+++ b/nsxt/resource_nsxt_lb_l4_monitor_test.go
@@ -42,7 +42,7 @@ func testAccResourceNsxtLbL4MonitorBasic(t *testing.T, protocol string) {
 	receive := "Server hello"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbL4MonitorCheckDestroy(protocol, state, name)
@@ -88,7 +88,7 @@ func testAccResourceNsxtLbL4MonitorImport(t *testing.T, protocol string) {
 	name := "test-nsx-monitor"
 	testResourceName := fmt.Sprintf("nsxt_lb_%s_monitor.test", protocol)
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbL4MonitorCheckDestroy(protocol, state, name)

--- a/nsxt/resource_nsxt_lb_l7_monitor_test.go
+++ b/nsxt/resource_nsxt_lb_l7_monitor_test.go
@@ -41,7 +41,7 @@ func testAccResourceNsxtLbL7MonitorBasic(t *testing.T, protocol string) {
 	body2 := "YYYYYYYYYYYYYYYYYYY"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbL7MonitorCheckDestroy(state, name)
@@ -86,7 +86,7 @@ func TestAccResourceNsxtLbHTTPSMonitor_withAuth(t *testing.T) {
 	testResourceName := "nsxt_lb_https_monitor.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			testAccNSXDeleteCerts(t, testLbMonitorCertID, testLbMonitorClientCertID, testLbMonitorCaCertID)
@@ -120,7 +120,7 @@ func testAccResourceNsxtLbL7MonitorImport(t *testing.T, protocol string) {
 	name := "test-nsx-monitor"
 	testResourceName := fmt.Sprintf("nsxt_lb_%s_monitor.test", protocol)
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbL7MonitorCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_lb_passive_monitor_test.go
+++ b/nsxt/resource_nsxt_lb_passive_monitor_test.go
@@ -21,7 +21,7 @@ func TestAccResourceNsxtLbPassiveMonitor_basic(t *testing.T) {
 	updatedTimeout := "7"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbPassiveMonitorCheckDestroy(state, name)
@@ -57,7 +57,7 @@ func TestAccResourceNsxtLbPassiveMonitor_importBasic(t *testing.T) {
 	name := "test-nsx-monitor"
 	testResourceName := "nsxt_lb_passive_monitor.test"
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbPassiveMonitorCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_lb_pool_test.go
+++ b/nsxt/resource_nsxt_lb_pool_test.go
@@ -24,7 +24,7 @@ func TestAccResourceNsxtLbPool_basic(t *testing.T) {
 	updatedSnatTranslationType := "SNAT_AUTO_MAP"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbPoolCheckDestroy(state, name)
@@ -66,7 +66,7 @@ func TestAccResourceNsxtLbPool_withMonitors(t *testing.T) {
 	testResourceName := "nsxt_lb_pool.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbPoolCheckDestroy(state, name)
@@ -114,7 +114,7 @@ func TestAccResourceNsxtLbPool_withIpSnat(t *testing.T) {
 	updatedIPAddress := "1.1.1.2-1.1.1.20"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbPoolCheckDestroy(state, name)
@@ -165,7 +165,7 @@ func TestAccResourceNsxtLbPool_withMember(t *testing.T) {
 	memberIP := "1.1.1.1"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbPoolCheckDestroy(state, name)
@@ -215,7 +215,7 @@ func TestAccResourceNsxtLbPool_withMemberGroup(t *testing.T) {
 	updatedPort := "60"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbPoolCheckDestroy(state, name)
@@ -265,7 +265,7 @@ func TestAccResourceNsxtLbPool_importBasic(t *testing.T) {
 	name := "test-nsx-lb-pool"
 	testResourceName := "nsxt_lb_pool.test"
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbPoolCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_lb_server_ssl_profile_test.go
+++ b/nsxt/resource_nsxt_lb_server_ssl_profile_test.go
@@ -18,7 +18,7 @@ func TestAccResourceNsxtLbServerSSLProfile_basic(t *testing.T) {
 	testResourceName := "nsxt_lb_server_ssl_profile.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbServerSSLProfileCheckDestroy(state, name)
@@ -58,7 +58,7 @@ func TestAccResourceNsxtLbServerSSLProfile_importBasic(t *testing.T) {
 	name := "test"
 	testResourceName := "nsxt_lb_server_ssl_profile.test"
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbServerSSLProfileCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_logical_router_centralized_service_port_test.go
+++ b/nsxt/resource_nsxt_logical_router_centralized_service_port_test.go
@@ -21,7 +21,7 @@ func TestAccResourceNsxtLogicalRouterCentralizedServicePort_basic(t *testing.T) 
 	routerObj := "nsxt_logical_tier1_router.rtr1.id"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalRouterCentralizedServicePortCheckDestroy(state, portName)
@@ -66,7 +66,7 @@ func TestAccResourceNsxtLogicalRouterCentralizedServicePort_onTier0(t *testing.T
 	routerObj := "data.nsxt_logical_tier0_router.tier0rtr.id"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalRouterCentralizedServicePortCheckDestroy(state, portName)
@@ -110,7 +110,7 @@ func TestAccResourceNsxtLogicalRouterCentralizedServicePort_importBasic(t *testi
 	routerObj := "nsxt_logical_tier1_router.rtr1.id"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalRouterCentralizedServicePortCheckDestroy(state, portName)
@@ -135,7 +135,7 @@ func TestAccResourceNsxtLogicalRouterCentralizedServicePort_onTier1(t *testing.T
 	edgeClusterName := getEdgeClusterName()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalRouterCentralizedServicePortCheckDestroy(state, portName)


### PR DESCRIPTION
LB and centralized port features are not fully supported pre 2.3.0