### PR TITLE
Removed extra ` from line 45 after }

### DIFF
--- a/website/docs/r/lb_service.html.markdown
+++ b/website/docs/r/lb_service.html.markdown
@@ -42,7 +42,7 @@ resource "nsxt_logical_tier1_router" "test" {
 resource "nsxt_logical_router_link_port_on_tier1" "test" {
   logical_router_id             = "${nsxt_logical_tier1_router.test.id}"
   linked_logical_router_port_id = "${nsxt_logical_router_link_port_on_tier0.test.id}"
-}`
+}
 
 resource "nsxt_lb_service" "lb_service" {
   description  = "lb_service provisioned by Terraform"


### PR DESCRIPTION
` at the end of line 45 after the } was breaking syntax highlighting and invalidated the example code.