### PR TITLE
Pass IDs for the FW sections and rules for update

### DIFF
--- a/nsxt/resource_nsxt_firewall_section.go
+++ b/nsxt/resource_nsxt_firewall_section.go
@@ -214,6 +214,7 @@ func getRulesFromSchema(d *schema.ResourceData) []manager.FirewallRule {
 		data := rule.(map[string]interface{})
 		elem := manager.FirewallRule{
 			DisplayName:          data["display_name"].(string),
+			Id:                   data["id"].(string),
 			RuleTag:              data["rule_tag"].(string),
 			Notes:                data["notes"].(string),
 			Description:          data["description"].(string),
@@ -357,6 +358,7 @@ func resourceNsxtFirewallSectionUpdate(d *schema.ResourceData, m interface{}) er
 			AppliedTos:  appliedTos,
 			SectionType: sectionType,
 			Stateful:    stateful,
+			Id:          id,
 		},
 		Rules: rules,
 	}


### PR DESCRIPTION
Currently when updating a firewall rules internally they get
deleted and the new ones are created (causing their IDs to change).
This is not always a desired behaviour, as the NSX-T API itself
allows changing the rules in place.

This patch adds the current firewall section and rule ID to the
payload in order to allow preserving the IDs.