### PR TITLE
Support for LogicalRouter FirewallSection and LogicalRouterPort Rule

### DIFF
--- a/nsxt/resource_nsxt_firewall_section.go
+++ b/nsxt/resource_nsxt_firewall_section.go
@@ -59,7 +59,7 @@ func resourceNsxtFirewallSection() *schema.Resource {
 				Required:    true,
 				ForceNew:    true,
 			},
-			"applied_to": getResourceReferencesSetSchema(false, false, []string{"LogicalPort", "LogicalSwitch", "NSGroup"}, "List of objects where the rules in this section will be enforced. This will take precedence over rule level appliedTo"),
+			"applied_to": getResourceReferencesSetSchema(false, false, []string{"LogicalPort", "LogicalSwitch", "NSGroup", "LogicalRouter"}, "List of objects where the rules in this section will be enforced. This will take precedence over rule level appliedTo"),
 			"insert_before": {
 				Type:        schema.TypeString,
 				Description: "Id of section that should come after this one",
@@ -100,7 +100,7 @@ func getRulesSchema() *schema.Schema {
 					Required:     true,
 					ValidateFunc: validation.StringInSlice(firewallRuleActionValues, false),
 				},
-				"applied_to":  getResourceReferencesSetSchema(false, false, []string{"LogicalPort", "LogicalSwitch", "NSGroup"}, "List of objects where rule will be enforced. The section level field overrides this one. Null will be treated as any"),
+				"applied_to":  getResourceReferencesSetSchema(false, false, []string{"LogicalPort", "LogicalSwitch", "NSGroup", "LogicalRouterPort"}, "List of objects where rule will be enforced. The section level field overrides this one. Null will be treated as any"),
 				"destination": getResourceReferencesSetSchema(false, false, []string{"IPSet", "LogicalPort", "LogicalSwitch", "NSGroup", "MACSet"}, "List of the destinations. Null will be treated as any"),
 				"destinations_excluded": {
 					Type:        schema.TypeBool,

--- a/website/docs/r/firewall_section.html.markdown
+++ b/website/docs/r/firewall_section.html.markdown
@@ -80,7 +80,7 @@ The following arguments are supported:
 * `display_name` - (Optional) The display name of this firewall section. Defaults to ID if not set.
 * `description` - (Optional) Description of this firewall section.
 * `tag` - (Optional) A list of scope + tag pairs to associate with this firewall section.
-* `applied_to` - (Optional) List of objects where the rules in this section will be enforced. This will take precedence over rule level applied_to. [Supported target types: "LogicalPort", "LogicalSwitch", "NSGroup"]
+* `applied_to` - (Optional) List of objects where the rules in this section will be enforced. This will take precedence over rule level applied_to. [Supported target types: "LogicalPort", "LogicalSwitch", "NSGroup", "LogicalRouter"]
 * `section_type` - (Required) Type of the rules which a section can contain. Either LAYER2 or LAYER3. Only homogeneous sections are supported.
 * `stateful` - (Required) Stateful or Stateless nature of firewall section is enforced on all rules inside the section. Layer3 sections can be stateful or stateless. Layer2 sections can only be stateless.
 * `insert_before` - (Optional) Firewall section id that should come immediately after this one. It is user responsibility to use this attribute in consistent manner (for example, if same value would be set in two separate sections, the outcome would depend on order of creation). Changing this attribute would force recreation of the firewall section.
@@ -88,7 +88,7 @@ The following arguments are supported:
   * `display_name` - (Optional) The display name of this rule. Defaults to ID if not set.
   * `description` - (Optional) Description of this rule.
   * `action` - (Required) Action enforced on the packets which matches the firewall rule. [Allowed values: "ALLOW", "DROP", "REJECT"]
-  * `applied_to` - (Optional) List of objects where rule will be enforced. The section level field overrides this one. Null will be treated as any. [Supported target types: "LogicalPort", "LogicalSwitch", "NSGroup"]
+  * `applied_to` - (Optional) List of objects where rule will be enforced. The section level field overrides this one. Null will be treated as any. [Supported target types: "LogicalPort", "LogicalSwitch", "NSGroup", "LogicalRouterPort"]
   * `destination` - (Optional) List of the destinations. Null will be treated as any. [Allowed target types: "IPSet", "LogicalPort", "LogicalSwitch", "NSGroup", "MACSet" (depending on the section type)]
   * `destinations_excluded` - (Optional) When this boolean flag is set to true, the rule destinations will be negated.
   * `direction` - (Optional) Rule direction in case of stateless firewall rules. This will only considered if section level parameter is set to stateless. Default to IN_OUT if not specified. [Allowed values: "IN", "OUT", "IN_OUT"]


### PR DESCRIPTION
EdgeFirewall sections cannot currently be edited due to lack of support for LogicalRouter applied_to sections. In a similar way, it is not possible to create a rule within a edge firewall section that applies to only a LogicalRouterPort.

Both are within /firewall/sections and can be updated using same API as DFW rules so there should be no reason the provider can't be used for them.