### PR TITLE
Fix nat READ for non-existant rule

### DIFF
--- a/nsxt/resource_nsxt_nat_rule.go
+++ b/nsxt/resource_nsxt_nat_rule.go
@@ -163,13 +163,15 @@ func resourceNsxtNatRuleRead(d *schema.ResourceData, m interface{}) error {
 	}
 
 	natRule, resp, err := nsxClient.LogicalRoutingAndServicesApi.GetNatRule(nsxClient.Context, logicalRouterID, id)
-	if err != nil {
-		return fmt.Errorf("Error during NatRule read: %v", err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && (resp.StatusCode == http.StatusBadRequest || resp.StatusCode == http.StatusNotFound) {
+		// Due to platform bug, 400 response is returned when NAT rule is not found
+		// In this case terraform should not error out
 		log.Printf("[DEBUG] NatRule %s not found", id)
 		d.SetId("")
 		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error during NatRule read: %v", err)
 	}
 
 	d.Set("revision", natRule.Revision)


### PR DESCRIPTION
NSX returns 400 response code for NAT rule that can not be found,
instead of the conventional 404. This leads to provider erroring out,
while it should just detect resource absence. To work around this,
this change handles 400 response code as if it was 404.