### PR TITLE
Enable logical port tags config for discovered VM

### DIFF
--- a/nsxt/resource_nsxt_vm_tags_test.go
+++ b/nsxt/resource_nsxt_vm_tags_test.go
@@ -29,6 +29,9 @@ func TestAccResourceNsxtVMTags_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccNSXVMTagsCheckExists(),
 					resource.TestCheckResourceAttr(vmTagsFullResourceName, "tag.#", "1"),
+					resource.TestCheckResourceAttr(vmTagsFullResourceName, "logical_port_tag.#", "1"),
+					resource.TestCheckResourceAttr(vmTagsFullResourceName, "logical_port_tag.934310497.scope", "a"),
+					resource.TestCheckResourceAttr(vmTagsFullResourceName, "logical_port_tag.934310497.tag", "b"),
 				),
 			},
 			{
@@ -36,6 +39,9 @@ func TestAccResourceNsxtVMTags_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccNSXVMTagsCheckExists(),
 					resource.TestCheckResourceAttr(vmTagsFullResourceName, "tag.#", "2"),
+					resource.TestCheckResourceAttr(vmTagsFullResourceName, "logical_port_tag.#", "1"),
+					resource.TestCheckResourceAttr(vmTagsFullResourceName, "logical_port_tag.600822426.scope", "c"),
+					resource.TestCheckResourceAttr(vmTagsFullResourceName, "logical_port_tag.600822426.tag", "d"),
 				),
 			},
 		},
@@ -119,6 +125,11 @@ resource "nsxt_vm_tags" "%s" {
     scope = "scope1"
     tag   = "tag1"
   }
+
+  logical_port_tag {
+    scope = "a"
+    tag   = "b"
+  }
 }`, vmTagsResourceName, instanceID)
 }
 
@@ -135,6 +146,11 @@ resource "nsxt_vm_tags" "%s" {
   tag {
     scope = "scope2"
     tag   = "tag2"
+  }
+
+  logical_port_tag {
+    scope = "c"
+    tag   = "d"
   }
 }`, vmTagsResourceName, instanceID)
 }

--- a/nsxt/utils.go
+++ b/nsxt/utils.go
@@ -115,8 +115,8 @@ func getTagsSchemaForceNew() *schema.Schema {
 	return getTagsSchemaInternal(true)
 }
 
-func getTagsFromSchema(d *schema.ResourceData) []common.Tag {
-	tags := d.Get("tag").(*schema.Set).List()
+func getCustomizedTagsFromSchema(d *schema.ResourceData, schemaName string) []common.Tag {
+	tags := d.Get(schemaName).(*schema.Set).List()
 	var tagList []common.Tag
 	for _, tag := range tags {
 		data := tag.(map[string]interface{})
@@ -129,7 +129,7 @@ func getTagsFromSchema(d *schema.ResourceData) []common.Tag {
 	return tagList
 }
 
-func setTagsInSchema(d *schema.ResourceData, tags []common.Tag) error {
+func setCustomizedTagsInSchema(d *schema.ResourceData, tags []common.Tag, schemaName string) error {
 	var tagList []map[string]string
 	for _, tag := range tags {
 		elem := make(map[string]string)
@@ -137,8 +137,15 @@ func setTagsInSchema(d *schema.ResourceData, tags []common.Tag) error {
 		elem["tag"] = tag.Tag
 		tagList = append(tagList, elem)
 	}
-	err := d.Set("tag", tagList)
+	err := d.Set(schemaName, tagList)
 	return err
+}
+func getTagsFromSchema(d *schema.ResourceData) []common.Tag {
+	return getCustomizedTagsFromSchema(d, "tag")
+}
+
+func setTagsInSchema(d *schema.ResourceData, tags []common.Tag) error {
+	return setCustomizedTagsInSchema(d, tags, "tag")
 }
 
 // utilities to define & handle switching profiles

--- a/website/docs/r/vm_tags.html.markdown
+++ b/website/docs/r/vm_tags.html.markdown
@@ -19,6 +19,11 @@ resource "nsxt_vm_tags" "vm1_tags" {
     scope = "color"
     tag   = "blue"
   }
+
+  logical_port_tag {
+    scope = "color"
+    tag   = "blue"
+  }
 }
 ```
 
@@ -27,7 +32,8 @@ resource "nsxt_vm_tags" "vm1_tags" {
 The following arguments are supported:
 
 * `instance_id` - (Required) BIOS Id of the Virtual Machine.
-* `tag` - (Required) A list of scope + tag pairs to associate with this VM.
+* `tag` - (Optional) A list of scope + tag pairs to associate with this VM.
+* `logical_port_tag` - (Optional) A list of scope + tag pairs to associate with logical port that is automatically created for this VM.
 
 ## Importing
 


### PR DESCRIPTION
When VM is created in vsphere provider, a logical port is created
automatically (not managed by terraform). This patch extends
nsxt_vm_tags resource to enable user to configure tags on this port
in addition to the ability to configure tags on the VM.