### PR TITLE
Fix resource type for dhcp relay attachment

### DIFF
--- a/nsxt/resource_nsxt_logical_router_downlink_port.go
+++ b/nsxt/resource_nsxt_logical_router_downlink_port.go
@@ -71,7 +71,7 @@ func resourceNsxtLogicalRouterDownLinkPort() *schema.Resource {
 				Default:      "STRICT",
 				ValidateFunc: validation.StringInSlice(logicalRouterPortUrpfModeValues, false),
 			},
-			"service_binding": getResourceReferencesSchema(false, false, []string{"LogicalService"}, "Service Bindings"),
+			"service_binding": getResourceReferencesSchema(false, false, []string{"LogicalService", "DhcpRelayService"}, "Service Bindings"),
 		},
 	}
 }


### PR DESCRIPTION
In NSX 2.5, resource type for dhcp relay attachment on router
downlink port has changed.
This patch extends validation to allow new type, and fixes the test
to assign and validate resource type based on backend version.