### PR TITLE
Fix resource type for dhcp relay attachment

### DIFF
--- a/nsxt/provider_test.go
+++ b/nsxt/provider_test.go
@@ -44,6 +44,10 @@ func testAccPreCheck(t *testing.T) {
 }
 
 func testAccGetClient() (*api.APIClient, error) {
+	if os.Getenv("NSXT_MANAGER_HOST") == "" {
+		return nil, fmt.Errorf("NSXT_MANAGER_HOST is not set in environment")
+	}
+
 	client, ok := testAccProvider.Meta().(*api.APIClient)
 	if ok {
 		return client, nil

--- a/nsxt/resource_nsxt_logical_router_downlink_port.go
+++ b/nsxt/resource_nsxt_logical_router_downlink_port.go
@@ -71,7 +71,7 @@ func resourceNsxtLogicalRouterDownLinkPort() *schema.Resource {
 				Default:      "STRICT",
 				ValidateFunc: validation.StringInSlice(logicalRouterPortUrpfModeValues, false),
 			},
-			"service_binding": getResourceReferencesSchema(false, false, []string{"LogicalService"}, "Service Bindings"),
+			"service_binding": getResourceReferencesSchema(false, false, []string{"LogicalService", "DhcpRelayService"}, "Service Bindings"),
 		},
 	}
 }


### PR DESCRIPTION
In NSX 2.5, resource type for dhcp relay attachment on router
downlink port has changed.
This patch extends validation to allow new type, and fixes the test
to assign and validate resource type based on backend version.