### PR TITLE
Add provider flag to tolerate partial success

### DIFF
--- a/nsxt/provider.go
+++ b/nsxt/provider.go
@@ -11,6 +11,7 @@ import (
 )
 
 var defaultRetryOnStatusCodes = []int{429, 503}
+var toleratePartialSuccess = false
 
 // Provider for VMWare NSX-T. Returns terraform.ResourceProvider
 func Provider() terraform.ResourceProvider {
@@ -84,6 +85,12 @@ func Provider() terraform.ResourceProvider {
 					Type: schema.TypeInt,
 				},
 				// There is no support for default values/func for list, so it will be handled later
+			},
+			"tolerate_partial_success": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Treat partial success status as success",
+				DefaultFunc: schema.EnvDefaultFunc("NSXT_TOLERATE_PARTIAL_SUCCESS", false),
 			},
 		},
 
@@ -188,6 +195,9 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	username := d.Get("username").(string)
 	password := d.Get("password").(string)
 	remoteAuth := d.Get("remote_auth").(bool)
+
+	// Global variable used in resources with realization checks
+	toleratePartialSuccess = d.Get("tolerate_partial_success").(bool)
 
 	if needCreds {
 		if username == "" {

--- a/nsxt/resource_nsxt_logical_switch.go
+++ b/nsxt/resource_nsxt_logical_switch.go
@@ -143,9 +143,16 @@ func resourceNsxtLogicalSwitchCreate(d *schema.ResourceData, m interface{}) erro
 
 func resourceNsxtLogicalSwitchVerifyRealization(d *schema.ResourceData, nsxClient *api.APIClient, logicalSwitch *manager.LogicalSwitch) error {
 	// verifying switch realization on hypervisor
+	pendingStates := []string{"in_progress", "pending"}
+	targetStates := []string{"success"}
+	if toleratePartialSuccess {
+		targetStates = append(targetStates, "partial_success")
+	} else {
+		pendingStates = append(pendingStates, "partial_success")
+	}
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{"in_progress", "pending", "partial_success"},
-		Target:  []string{"success"},
+		Pending: pendingStates,
+		Target:  targetStates,
 		Refresh: func() (interface{}, string, error) {
 			state, resp, err := nsxClient.LogicalSwitchingApi.GetLogicalSwitchState(nsxClient.Context, logicalSwitch.Id)
 			if err != nil {

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -150,6 +150,8 @@ The following arguments are used to configure the VMware NSX-T Provider:
   authorization. This is required for users based on vIDM authentication.
   The default for this flag is false. Can also be specified with the
   `NSXT_REMOTE_AUTH` environment variable.
+* `tolerate_partial_success` - (Optional) Setting this flag to true would treat
+  partially succesful realization as valid state and not fail apply.
 
 ## NSX Logical Networking
 


### PR DESCRIPTION
Before this change, when logical switch realization status was
partial success, provider failed configuration. This flag would
allow to treat partial success as valid state. Default setting for
this flag is false. Currently the flag only relates to logical
switch realization.