### PR TITLE
Allocate another env variable for vm port test

### DIFF
--- a/nsxt/utils_test.go
+++ b/nsxt/utils_test.go
@@ -90,6 +90,10 @@ func getTestVMID() string {
 	return os.Getenv("NSXT_TEST_VM_ID")
 }
 
+func getTestVMOnOpaqueSwitchID() string {
+	return os.Getenv("NSXT_TEST_VM_ON_OPAQUE_SWITCH_ID")
+}
+
 func testAccEnvDefined(t *testing.T, envVar string) {
 	if len(os.Getenv(envVar)) == 0 {
 		t.Skipf("This test requires %s environment variable to be set", envVar)


### PR DESCRIPTION
In order to pass test with port tags, VM needs to reside on opaque
switch. In order not to fail existing test setups, dedicate another
env variable for test of tagging VM port.