### PR TITLE
Add resource nsxt_ip_pool_allocation_ip_address

### DIFF
--- a/nsxt/data_source_nsxt_ip_pool.go
+++ b/nsxt/data_source_nsxt_ip_pool.go
@@ -1,4 +1,4 @@
-/* Copyright © 2017 VMware, Inc. All Rights Reserved.
+/* Copyright © 2019 VMware, Inc. All Rights Reserved.
    SPDX-License-Identifier: MPL-2.0 */
 
 package nsxt
@@ -48,11 +48,11 @@ func dataSourceNsxtIPPoolRead(d *schema.ResourceData, m interface{}) error {
 		// Get by id
 		objGet, resp, err := nsxClient.PoolManagementApi.ReadIpPool(nsxClient.Context, objID)
 
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return fmt.Errorf("IP pool %s was not found", objID)
+		}
 		if err != nil {
 			return fmt.Errorf("Error while reading ns service %s: %v", objID, err)
-		}
-		if resp.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("IP pool %s was not found", objID)
 		}
 		obj = objGet
 	} else if objName != "" {

--- a/nsxt/data_source_nsxt_ip_pool.go
+++ b/nsxt/data_source_nsxt_ip_pool.go
@@ -1,0 +1,87 @@
+/* Copyright © 2017 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/schema"
+	api "github.com/vmware/go-vmware-nsxt"
+	"github.com/vmware/go-vmware-nsxt/manager"
+	"net/http"
+)
+
+func dataSourceNsxtIPPool() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceNsxtIPPoolRead,
+
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Description: "Unique ID of this resource",
+				Optional:    true,
+				Computed:    true,
+			},
+			"display_name": {
+				Type:        schema.TypeString,
+				Description: "The display name of this resource",
+				Optional:    true,
+				Computed:    true,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Description: "Description of this resource",
+				Optional:    true,
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func dataSourceNsxtIPPoolRead(d *schema.ResourceData, m interface{}) error {
+	// Read IP Pool by name or id
+	nsxClient := m.(*api.APIClient)
+	objID := d.Get("id").(string)
+	objName := d.Get("display_name").(string)
+	var obj manager.IpPool
+	if objID != "" {
+		// Get by id
+		objGet, resp, err := nsxClient.PoolManagementApi.ReadIpPool(nsxClient.Context, objID)
+
+		if err != nil {
+			return fmt.Errorf("Error while reading ns service %s: %v", objID, err)
+		}
+		if resp.StatusCode == http.StatusNotFound {
+			return fmt.Errorf("IP pool %s was not found", objID)
+		}
+		obj = objGet
+	} else if objName != "" {
+		// Get by full name
+		objList, _, err := nsxClient.PoolManagementApi.ListIpPools(nsxClient.Context, nil)
+		if err != nil {
+			return fmt.Errorf("Error while reading IP pool: %v", err)
+		}
+		// go over the list to find the correct one
+		found := false
+		for _, objInList := range objList.Results {
+			if objInList.DisplayName == objName {
+				if found {
+					return fmt.Errorf("Found multiple IP pool with name '%s'", objName)
+				}
+				obj = objInList
+				found = true
+			}
+		}
+		if !found {
+			return fmt.Errorf("IP pool '%s' was not found out of %d services", objName, len(objList.Results))
+		}
+	} else {
+		return fmt.Errorf("Error obtaining IP pool ID or name during read")
+	}
+
+	d.SetId(obj.Id)
+	d.Set("display_name", obj.DisplayName)
+	d.Set("description", obj.Description)
+
+	return nil
+}

--- a/nsxt/data_source_nsxt_ip_pool_test.go
+++ b/nsxt/data_source_nsxt_ip_pool_test.go
@@ -1,4 +1,4 @@
-/* Copyright © 2017 VMware, Inc. All Rights Reserved.
+/* Copyright © 2019 VMware, Inc. All Rights Reserved.
    SPDX-License-Identifier: MPL-2.0 */
 
 package nsxt
@@ -10,7 +10,10 @@ import (
 )
 
 func TestAccDataSourceNsxtIPPool_basic(t *testing.T) {
-	ipPoolName := getIpPoolName()
+	ipPoolName := getIPPoolName()
+	if ipPoolName == "" {
+		t.Skipf("No NSXT_TEST_IP_POOL set - skipping test")
+	}
 	testResourceName := "data.nsxt_ip_pool.test"
 
 	resource.Test(t, resource.TestCase{

--- a/nsxt/data_source_nsxt_ip_pool_test.go
+++ b/nsxt/data_source_nsxt_ip_pool_test.go
@@ -1,0 +1,36 @@
+/* Copyright © 2017 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/resource"
+	"testing"
+)
+
+func TestAccDataSourceNsxtIPPool_basic(t *testing.T) {
+	ipPoolName := getIpPoolName()
+	testResourceName := "data.nsxt_ip_pool.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNSXIPPoolReadTemplate(ipPoolName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(testResourceName, "display_name", ipPoolName),
+					resource.TestCheckResourceAttrSet(testResourceName, "id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccNSXIPPoolReadTemplate(name string) string {
+	return fmt.Sprintf(`
+data "nsxt_ip_pool" "test" {
+  display_name = "%s"
+}`, name)
+}

--- a/nsxt/provider.go
+++ b/nsxt/provider.go
@@ -104,6 +104,7 @@ func Provider() terraform.ResourceProvider {
 			"nsxt_ns_service":           dataSourceNsxtNsService(),
 			"nsxt_edge_cluster":         dataSourceNsxtEdgeCluster(),
 			"nsxt_certificate":          dataSourceNsxtCertificate(),
+			"nsxt_ip_pool":              dataSourceNsxtIPPool(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -140,6 +141,7 @@ func Provider() terraform.ResourceProvider {
 			"nsxt_ip_block":                                resourceNsxtIPBlock(),
 			"nsxt_ip_block_subnet":                         resourceNsxtIPBlockSubnet(),
 			"nsxt_ip_pool":                                 resourceNsxtIPPool(),
+			"nsxt_ip_pool_allocation_ip_address":           resourceNsxtIPPoolAllocationIPAddress(),
 			"nsxt_ip_set":                                  resourceNsxtIPSet(),
 			"nsxt_static_route":                            resourceNsxtStaticRoute(),
 			"nsxt_vm_tags":                                 resourceNsxtVMTags(),

--- a/nsxt/resource_nsxt_ip_pool_allocation_ip_address.go
+++ b/nsxt/resource_nsxt_ip_pool_allocation_ip_address.go
@@ -1,0 +1,122 @@
+/* Copyright © 2018 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/schema"
+	api "github.com/vmware/go-vmware-nsxt"
+	"github.com/vmware/go-vmware-nsxt/manager"
+	"log"
+	"net/http"
+)
+
+func resourceNsxtIPPoolAllocationIPAddress() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceNsxtIPPoolAllocationIPAddressCreate,
+		Read:   resourceNsxtIPPoolAllocationIPAddressRead,
+		Update: resourceNsxtIPPoolAllocationIPAddressUpdate,
+		Delete: resourceNsxtIPPoolAllocationIPAddressDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"ip_pool_id": {
+				Type:        schema.TypeString,
+				Description: "ID of IP pool that allocation belongs to",
+				Required:    true,
+			},
+			"allocation_id": {
+				Type:        schema.TypeString,
+				Description: "IP Address that is allocated from the pool",
+				Optional:    true,
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func resourceNsxtIPPoolAllocationIPAddressCreate(d *schema.ResourceData, m interface{}) error {
+	nsxClient := m.(*api.APIClient)
+	poolId := d.Get("ip_pool_id").(string)
+	allocationId := d.Get("allocation_id").(string)
+	allocationIpAddress := manager.AllocationIpAddress{
+		AllocationId: allocationId,
+	}
+
+	allocationIpAddress, resp, err := nsxClient.PoolManagementApi.AllocateOrReleaseFromIpPool(nsxClient.Context, poolId, allocationIpAddress, "ALLOCATE")
+
+	if err != nil {
+		return fmt.Errorf("Error during IpPoolAllocationIpAddress create: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("Unexpected status returned during IpPoolAllocationIpAddress create: %v", resp.StatusCode)
+	}
+	d.SetId(allocationIpAddress.AllocationId)
+
+	return resourceNsxtIPPoolAllocationIPAddressRead(d, m)
+}
+
+func resourceNsxtIPPoolAllocationIPAddressRead(d *schema.ResourceData, m interface{}) error {
+	nsxClient := m.(*api.APIClient)
+	id := d.Id()
+	if id == "" {
+		return fmt.Errorf("Error obtaining logical object id")
+	}
+	poolId := d.Get("ip_pool_id").(string)
+	if id == "" {
+		return fmt.Errorf("Error obtaining pool id")
+	}
+
+	resultList, resp, err := nsxClient.PoolManagementApi.ListIpPoolAllocations(nsxClient.Context, poolId)
+	if err != nil {
+		return fmt.Errorf("Error during IPPoolAllocationIPAddress read: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("Unexpected status returned during IpPoolAllocationIpAddress read: %v", resp.StatusCode)
+	}
+
+	for _, address := range resultList.Results {
+		if address.AllocationId == id {
+			d.Set("ip_pool_id", poolId)
+			d.Set("allocation_id", address.AllocationId)
+			return nil
+		}
+	}
+
+	log.Printf("[DEBUG] IPPoolAllocationIPAddress list%s not found", id)
+	d.SetId("")
+	return nil
+}
+
+func resourceNsxtIPPoolAllocationIPAddressUpdate(d *schema.ResourceData, m interface{}) error {
+	return fmt.Errorf("Updating IPPoolAllocationIPAddress is not supported")
+}
+
+func resourceNsxtIPPoolAllocationIPAddressDelete(d *schema.ResourceData, m interface{}) error {
+	nsxClient := m.(*api.APIClient)
+	id := d.Id()
+	if id == "" {
+		return fmt.Errorf("Error obtaining logical object id")
+	}
+	poolId := d.Get("ip_pool_id").(string)
+	if id == "" {
+		return fmt.Errorf("Error obtaining pool id")
+	}
+
+	allocationIpAddress := manager.AllocationIpAddress{
+		AllocationId: d.Id(),
+	}
+	_, resp, err := nsxClient.PoolManagementApi.AllocateOrReleaseFromIpPool(nsxClient.Context, poolId, allocationIpAddress, "RELEASE")
+	if resp == nil && err != nil {
+		return fmt.Errorf("Error during IPPoolAllocationIPAddress delete: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("Error during IPPoolAllocationIPAddress delete: status=%s", resp.Status)
+	}
+	return nil
+}

--- a/nsxt/resource_nsxt_ip_pool_allocation_ip_address_test.go
+++ b/nsxt/resource_nsxt_ip_pool_allocation_ip_address_test.go
@@ -1,0 +1,140 @@
+/* Copyright © 2018 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/vmware/go-vmware-nsxt"
+	"math/rand"
+	"net/http"
+	"testing"
+	"time"
+)
+
+const (
+	// how often to check destroyment of allocated ip address
+	destroyTestPercent = 10
+
+	// how long to wait for updated allocation IP address list (to check destroyment)
+	waitSeconds = 120
+)
+
+func TestAccResourceNsxtIpPoolAllocationIPAddress_basic(t *testing.T) {
+	poolName := getIpPoolName()
+	poolResourceName := "data.nsxt_ip_pool.acceptance_test"
+	resourceName := "nsxt_ip_pool_allocation_ip_address.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNSXIpPoolAllocationIPAddressCheckDestroy(state, poolResourceName, resourceName)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNSXIpPoolAllocationIPAddressCreateTemplate(poolName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNSXIpPoolAllocationIPAddressExists(poolResourceName, resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "ip_pool_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "allocation_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccNSXIpPoolAllocationIPAddressExists(poolResourceName string, resourceName string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		exists, err := checkAllocationIPAddressExists(state, poolResourceName, resourceName)
+		if err != nil {
+			return err
+		}
+		if !*exists {
+			return fmt.Errorf("Allocation %s in IP Pool %s is not existing", resourceName, poolResourceName)
+		}
+		return nil
+	}
+}
+
+func getIpPoolIdByResourceName(state *terraform.State, poolResourceName string) (string, error) {
+	rsPool, ok := state.RootModule().Resources[poolResourceName]
+	if !ok {
+		return "", fmt.Errorf("IP Pool resource %s not found in resources", getIpPoolName())
+	}
+
+	poolID := rsPool.Primary.ID
+	if poolID == "" {
+		return "", fmt.Errorf("IP Pool resource ID not set in resources ")
+	}
+	return poolID, nil
+}
+
+func checkAllocationIPAddressExists(state *terraform.State, poolResourceName string, resourceName string) (*bool, error) {
+	poolID, err := getIpPoolIdByResourceName(state, poolResourceName)
+	if err != nil {
+		return nil, err
+	}
+
+	rs, ok := state.RootModule().Resources[resourceName]
+	if !ok {
+		return nil, fmt.Errorf("IP Pool allocation_ip_address resource %s not found in resources", resourceName)
+	}
+
+	nsxClient := testAccProvider.Meta().(*nsxt.APIClient)
+	listResult, responseCode, err := nsxClient.PoolManagementApi.ListIpPoolAllocations(nsxClient.Context, poolID)
+	if err != nil {
+		return nil, fmt.Errorf("Error while retrieving allocations for IP Pool ID %s. Error: %v", poolID, err)
+	}
+
+	if responseCode.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Error while checking if allocations in IP Pool %s exists. HTTP return code was %d", poolID, responseCode.StatusCode)
+	}
+
+	exists := false
+	for _, allocationIpAddress := range listResult.Results {
+		if allocationIpAddress.AllocationId == rs.Primary.ID {
+			exists = true
+			break
+		}
+	}
+
+	return &exists, nil
+}
+
+func testAccNSXIpPoolAllocationIPAddressCheckDestroy(state *terraform.State, poolResourceName, resourceName string) error {
+	// PoolManagementApi.ListIpPoolAllocations() call does not return updated list within two minutes.
+	// Therefore the destroy check is only performed sporadically of test runs (per random) to avoid long test run
+	rnd100 := rand.NewSource(time.Now().UnixNano()).Int63() % 100
+	if rnd100 >= destroyTestPercent {
+		fmt.Printf("skipped testAccNSXIpPoolAllocationIPAddressCheckDestroy (%d >= %d)\n", rnd100, destroyTestPercent)
+		return nil
+	}
+	fmt.Printf("testAccNSXIpPoolAllocationIPAddressCheckDestroy: waiting up to %d seconds\n", waitSeconds)
+
+	timeout := time.Now().Add(waitSeconds * time.Second)
+	for time.Now().Before(timeout) {
+		exists, err := checkAllocationIPAddressExists(state, poolResourceName, resourceName)
+		if err != nil {
+			return err
+		}
+		if !*exists {
+			return nil
+		}
+		time.Sleep(1 * time.Second)
+	}
+	return fmt.Errorf("Timeout on check destroy IP address allocation")
+}
+
+func testAccNSXIpPoolAllocationIPAddressCreateTemplate(poolName string) string {
+	return fmt.Sprintf(`
+data "nsxt_ip_pool" "acceptance_test" {
+  display_name = "%s"
+}
+
+resource "nsxt_ip_pool_allocation_ip_address" "test" {
+  ip_pool_id = "${data.nsxt_ip_pool.acceptance_test.id}"
+}`, poolName)
+}

--- a/nsxt/resource_nsxt_ip_pool_allocation_ip_address_test.go
+++ b/nsxt/resource_nsxt_ip_pool_allocation_ip_address_test.go
@@ -1,4 +1,4 @@
-/* Copyright © 2018 VMware, Inc. All Rights Reserved.
+/* Copyright © 2019 VMware, Inc. All Rights Reserved.
    SPDX-License-Identifier: MPL-2.0 */
 
 package nsxt
@@ -8,22 +8,22 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/vmware/go-vmware-nsxt"
-	"math/rand"
 	"net/http"
 	"testing"
 	"time"
 )
 
 const (
-	// how often to check destroyment of allocated ip address
-	destroyTestPercent = 10
-
 	// how long to wait for updated allocation IP address list (to check destroyment)
-	waitSeconds = 120
+	waitSeconds = 150
 )
 
-func TestAccResourceNsxtIpPoolAllocationIPAddress_basic(t *testing.T) {
-	poolName := getIpPoolName()
+func TestAccResourceNsxtIPPoolAllocationIPAddress_basic(t *testing.T) {
+	poolName := getIPPoolName()
+	if poolName == "" {
+		t.Skipf("No NSXT_TEST_IP_POOL set - skipping test")
+	}
+
 	poolResourceName := "data.nsxt_ip_pool.acceptance_test"
 	resourceName := "nsxt_ip_pool_allocation_ip_address.test"
 
@@ -31,13 +31,13 @@ func TestAccResourceNsxtIpPoolAllocationIPAddress_basic(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXIpPoolAllocationIPAddressCheckDestroy(state, poolResourceName, resourceName)
+			return testAccNSXIPPoolAllocationIPAddressCheckDestroy(state, poolResourceName, resourceName)
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNSXIpPoolAllocationIPAddressCreateTemplate(poolName),
+				Config: testAccNSXIPPoolAllocationIPAddressCreateTemplate(poolName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccNSXIpPoolAllocationIPAddressExists(poolResourceName, resourceName),
+					testAccNSXIPPoolAllocationIPAddressExists(poolResourceName, resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "ip_pool_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "allocation_id"),
 				),
@@ -46,7 +46,7 @@ func TestAccResourceNsxtIpPoolAllocationIPAddress_basic(t *testing.T) {
 	})
 }
 
-func testAccNSXIpPoolAllocationIPAddressExists(poolResourceName string, resourceName string) resource.TestCheckFunc {
+func testAccNSXIPPoolAllocationIPAddressExists(poolResourceName string, resourceName string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
 		exists, err := checkAllocationIPAddressExists(state, poolResourceName, resourceName)
 		if err != nil {
@@ -59,10 +59,10 @@ func testAccNSXIpPoolAllocationIPAddressExists(poolResourceName string, resource
 	}
 }
 
-func getIpPoolIdByResourceName(state *terraform.State, poolResourceName string) (string, error) {
+func getIPPoolIDByResourceName(state *terraform.State, poolResourceName string) (string, error) {
 	rsPool, ok := state.RootModule().Resources[poolResourceName]
 	if !ok {
-		return "", fmt.Errorf("IP Pool resource %s not found in resources", getIpPoolName())
+		return "", fmt.Errorf("IP Pool resource %s not found in resources", getIPPoolName())
 	}
 
 	poolID := rsPool.Primary.ID
@@ -73,7 +73,7 @@ func getIpPoolIdByResourceName(state *terraform.State, poolResourceName string) 
 }
 
 func checkAllocationIPAddressExists(state *terraform.State, poolResourceName string, resourceName string) (*bool, error) {
-	poolID, err := getIpPoolIdByResourceName(state, poolResourceName)
+	poolID, err := getIPPoolIDByResourceName(state, poolResourceName)
 	if err != nil {
 		return nil, err
 	}
@@ -94,8 +94,8 @@ func checkAllocationIPAddressExists(state *terraform.State, poolResourceName str
 	}
 
 	exists := false
-	for _, allocationIpAddress := range listResult.Results {
-		if allocationIpAddress.AllocationId == rs.Primary.ID {
+	for _, allocationIPAddress := range listResult.Results {
+		if allocationIPAddress.AllocationId == rs.Primary.ID {
 			exists = true
 			break
 		}
@@ -104,15 +104,9 @@ func checkAllocationIPAddressExists(state *terraform.State, poolResourceName str
 	return &exists, nil
 }
 
-func testAccNSXIpPoolAllocationIPAddressCheckDestroy(state *terraform.State, poolResourceName, resourceName string) error {
-	// PoolManagementApi.ListIpPoolAllocations() call does not return updated list within two minutes.
-	// Therefore the destroy check is only performed sporadically of test runs (per random) to avoid long test run
-	rnd100 := rand.NewSource(time.Now().UnixNano()).Int63() % 100
-	if rnd100 >= destroyTestPercent {
-		fmt.Printf("skipped testAccNSXIpPoolAllocationIPAddressCheckDestroy (%d >= %d)\n", rnd100, destroyTestPercent)
-		return nil
-	}
-	fmt.Printf("testAccNSXIpPoolAllocationIPAddressCheckDestroy: waiting up to %d seconds\n", waitSeconds)
+func testAccNSXIPPoolAllocationIPAddressCheckDestroy(state *terraform.State, poolResourceName, resourceName string) error {
+	// PoolManagementApi.ListIpPoolAllocations() call does not return updated list within two minutes. Need to wait...
+	fmt.Printf("testAccNSXIPPoolAllocationIPAddressCheckDestroy: waiting up to %d seconds\n", waitSeconds)
 
 	timeout := time.Now().Add(waitSeconds * time.Second)
 	for time.Now().Before(timeout) {
@@ -128,7 +122,7 @@ func testAccNSXIpPoolAllocationIPAddressCheckDestroy(state *terraform.State, poo
 	return fmt.Errorf("Timeout on check destroy IP address allocation")
 }
 
-func testAccNSXIpPoolAllocationIPAddressCreateTemplate(poolName string) string {
+func testAccNSXIPPoolAllocationIPAddressCreateTemplate(poolName string) string {
 	return fmt.Sprintf(`
 data "nsxt_ip_pool" "acceptance_test" {
   display_name = "%s"

--- a/nsxt/utils_test.go
+++ b/nsxt/utils_test.go
@@ -87,12 +87,8 @@ func getMacPoolName() string {
 	return name
 }
 
-func getIpPoolName() string {
-	name := os.Getenv("NSXT_TEST_IP_POOL")
-	if name == "" {
-		name = ipPoolDefaultName
-	}
-	return name
+func getIPPoolName() string {
+	return os.Getenv("NSXT_TEST_IP_POOL")
 }
 
 func getTestVMID() string {

--- a/nsxt/utils_test.go
+++ b/nsxt/utils_test.go
@@ -21,6 +21,7 @@ const switchingProfileDefaultName string = "nsx-default-mac-profile"
 const vlanTransportZoneName string = "transportzone2"
 const overlayTransportZoneNamePrefix string = "1-transportzone"
 const macPoolDefaultName string = "DefaultMacPool"
+const ipPoolDefaultName string = "DefaultIpPool"
 
 const singleTag string = `
   tag {
@@ -82,6 +83,14 @@ func getMacPoolName() string {
 	name := os.Getenv("NSXT_TEST_MAC_POOL")
 	if name == "" {
 		name = macPoolDefaultName
+	}
+	return name
+}
+
+func getIpPoolName() string {
+	name := os.Getenv("NSXT_TEST_IP_POOL")
+	if name == "" {
+		name = ipPoolDefaultName
 	}
 	return name
 }

--- a/website/docs/d/ip_pool.html.markdown
+++ b/website/docs/d/ip_pool.html.markdown
@@ -1,0 +1,30 @@
+---
+layout: "nsxt"
+page_title: "NSXT: ip_pool"
+sidebar_current: "docs-nsxt-datasource-ip-pool"
+description: A IP pool data source.
+---
+
+# nsxt_ip_pool
+
+This data source provides information about a IP pool configured in NSX.
+
+## Example Usage
+
+```hcl
+data "nsxt_ip_pool" "ip_pool" {
+  display_name = "DefaultIpPool"
+}
+```
+
+## Argument Reference
+
+* `id` - (Optional) The ID of IP pool to retrieve
+
+* `display_name` - (Optional) The Display Name of the IP pool to retrieve.
+
+## Attributes Reference
+
+In addition to arguments listed above, the following attributes are exported:
+
+* `description` - The description of the IP pool.

--- a/website/docs/r/ip_pool_allocation_ip_address.html.markdown
+++ b/website/docs/r/ip_pool_allocation_ip_address.html.markdown
@@ -1,0 +1,36 @@
+---
+layout: "nsxt"
+page_title: "NSXT: nsxt_ip_pool_allocation_ip_address"
+sidebar_current: "docs-nsxt-resource-ip-pool-allocation-ip-address"
+description: |-
+  Provides a resource to allocate an IP address from an IP pool on NSX-T manager
+---
+
+# nsxt_ip_pool_allocation_ip_address
+
+Provides a resource to allocate an IP address from an IP pool on NSX-T manager
+
+## Example Usage
+
+```hcl
+data "nsxt_ip_pool" "ip_pool" {
+  display_name = "DefaultIpPool"
+}
+
+resource "nsxt_ip_pool_allocation_ip_address" "pool_ip_address" {
+  ip_pool_id = "${data.nsxt_ip_pool.ip_pool.id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `ip_pool_id` - (Required) Ip Pool ID from which the IP address will be allocated.
+
+## Attributes Reference
+
+In addition to arguments listed above, the following attributes are exported:
+
+* `id` - ID of the IP pool allocation IP address (currently identical to `allocation_ip`).
+* `allocation_ip` - Allocation IP address.

--- a/website/nsxt.erb
+++ b/website/nsxt.erb
@@ -16,6 +16,9 @@
                         <li<%= sidebar_current("docs-nsxt-datasource-edge-cluster") %>>
                             <a href="/docs/providers/nsxt/d/edge_cluster.html">nsxt_edge_cluster</a>
                         </li>
+                        <li<%= sidebar_current("docs-nsxt-datasource-ip-pool") %>>
+                            <a href="/docs/providers/nsxt/d/ip_pool.html">nsxt_ip_pool</a>
+                        </li>
                         <li<%= sidebar_current("docs-nsxt-datasource-logical-tier0-router") %>>
                             <a href="/docs/providers/nsxt/d/logical_tier0_router.html">nsxt_logical_tier0_router</a>
                         </li>
@@ -66,6 +69,9 @@
                         </li>
                         <li<%= sidebar_current("docs-nsxt-resource-ip-pool") %>>
                             <a href="/docs/providers/nsxt/r/ip_pool.html">nsxt_ip_pool</a>
+                        </li>
+                        <li<%= sidebar_current("docs-nsxt-resource-ip-pool-allocation-ip-address") %>>
+                            <a href="/docs/providers/nsxt/r/ip_pool_allocation_ip_address.html">nsxt_ip_pool_allocation_ip_address</a>
                         </li>
                         <li<%= sidebar_current("docs-nsxt-resource-ip-set") %>>
                             <a href="/docs/providers/nsxt/r/ip_set.html">nsxt_ip_set</a>


### PR DESCRIPTION
For allocating and releasing IP addresses from an IP pool, the resource `nsxt_ip_pool_allocation_ip_address` and the data source `nsxt_ip_pool` have been added.

Acceptance tests and documentation have also been added. For the data source and the allocation tests, an existing IP pool is needed. A new environmental variable `NSXT_TEST_IP_POOL` has been defined to specify it.

