### PR TITLE
fix refresh failures

### DIFF
--- a/nsxt/resource_nsxt_algorithm_type_ns_service.go
+++ b/nsxt/resource_nsxt_algorithm_type_ns_service.go
@@ -114,13 +114,13 @@ func resourceNsxtAlgorithmTypeNsServiceRead(d *schema.ResourceData, m interface{
 	}
 
 	nsService, resp, err := nsxClient.GroupingObjectsApi.ReadAlgTypeNSService(nsxClient.Context, id)
-	if err != nil {
-		return fmt.Errorf("Error during NsService read: %v", err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		log.Printf("[DEBUG] NsService %s not found", id)
 		d.SetId("")
 		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error during NsService read: %v", err)
 	}
 
 	nsserviceElement := nsService.NsserviceElement

--- a/nsxt/resource_nsxt_dhcp_relay_profile.go
+++ b/nsxt/resource_nsxt_dhcp_relay_profile.go
@@ -84,13 +84,13 @@ func resourceNsxtDhcpRelayProfileRead(d *schema.ResourceData, m interface{}) err
 	}
 
 	dhcpRelayProfile, resp, err := nsxClient.LogicalRoutingAndServicesApi.ReadDhcpRelayProfile(nsxClient.Context, id)
-	if err != nil {
-		return fmt.Errorf("Error during DhcpRelayProfile read: %v", err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		log.Printf("[DEBUG] DhcpRelayProfile %s not found", id)
 		d.SetId("")
 		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error during DhcpRelayProfile read: %v", err)
 	}
 
 	d.Set("revision", dhcpRelayProfile.Revision)

--- a/nsxt/resource_nsxt_dhcp_relay_service.go
+++ b/nsxt/resource_nsxt_dhcp_relay_service.go
@@ -80,13 +80,13 @@ func resourceNsxtDhcpRelayServiceRead(d *schema.ResourceData, m interface{}) err
 	}
 
 	dhcpRelayService, resp, err := nsxClient.LogicalRoutingAndServicesApi.ReadDhcpRelay(nsxClient.Context, id)
-	if err != nil {
-		return fmt.Errorf("Error during DhcpRelayService read: %v", err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		log.Printf("[DEBUG] DhcpRelayService %s not found", id)
 		d.SetId("")
 		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error during DhcpRelayService read: %v", err)
 	}
 
 	d.Set("revision", dhcpRelayService.Revision)

--- a/nsxt/resource_nsxt_dhcp_server_ip_pool.go
+++ b/nsxt/resource_nsxt_dhcp_server_ip_pool.go
@@ -113,13 +113,11 @@ func resourceNsxtDhcpServerIPPoolCreate(d *schema.ResourceData, m interface{}) e
 	}
 
 	createdPool, resp, err := nsxClient.ServicesApi.CreateDhcpIpPool(nsxClient.Context, serverID, pool)
-
+	if resp != nil && resp.StatusCode != http.StatusCreated {
+		return fmt.Errorf("Unexpected status returned during DhcpIPPool create: %v", resp.StatusCode)
+	}
 	if err != nil {
 		return fmt.Errorf("Error during DhcpIPPool create: %v", err)
-	}
-
-	if resp.StatusCode != http.StatusCreated {
-		return fmt.Errorf("Unexpected status returned during DhcpIPPool create: %v", resp.StatusCode)
 	}
 
 	d.SetId(createdPool.Id)

--- a/nsxt/resource_nsxt_dhcp_server_profile.go
+++ b/nsxt/resource_nsxt_dhcp_server_profile.go
@@ -91,7 +91,7 @@ func resourceNsxtDhcpServerProfileRead(d *schema.ResourceData, m interface{}) er
 	}
 
 	dhcpProfile, resp, err := nsxClient.ServicesApi.ReadDhcpProfile(nsxClient.Context, id)
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		log.Printf("[DEBUG] DhcpProfile %s not found", id)
 		d.SetId("")
 		return nil

--- a/nsxt/resource_nsxt_ether_type_ns_service.go
+++ b/nsxt/resource_nsxt_ether_type_ns_service.go
@@ -90,13 +90,13 @@ func resourceNsxtEtherTypeNsServiceRead(d *schema.ResourceData, m interface{}) e
 	}
 
 	nsService, resp, err := nsxClient.GroupingObjectsApi.ReadEtherTypeNSService(nsxClient.Context, id)
-	if err != nil {
-		return fmt.Errorf("Error during NsService read: %v", err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		log.Printf("[DEBUG] NsService %s not found", id)
 		d.SetId("")
 		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error during NsService read: %v", err)
 	}
 
 	nsserviceElement := nsService.NsserviceElement

--- a/nsxt/resource_nsxt_firewall_section.go
+++ b/nsxt/resource_nsxt_firewall_section.go
@@ -320,7 +320,7 @@ func resourceNsxtFirewallSectionRead(d *schema.ResourceData, m interface{}) erro
 
 	// Getting the applied tos will require another api call (for NSX 2.1 or less)
 	firewallSection2, resp, err := nsxClient.ServicesApi.GetSection(nsxClient.Context, id)
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		log.Printf("[DEBUG] FirewallSection %s not found", id)
 		d.SetId("")
 		return nil

--- a/nsxt/resource_nsxt_icmp_type_ns_service.go
+++ b/nsxt/resource_nsxt_icmp_type_ns_service.go
@@ -90,14 +90,13 @@ func resourceNsxtIcmpTypeNsServiceCreate(d *schema.ResourceData, m interface{}) 
 	}
 
 	nsService, resp, err := nsxClient.GroupingObjectsApi.CreateIcmpTypeNSService(nsxClient.Context, nsService)
-
+	if resp != nil && resp.StatusCode != http.StatusCreated {
+		return fmt.Errorf("Unexpected status returned during NsService create: %v", resp.StatusCode)
+	}
 	if err != nil {
 		return fmt.Errorf("Error during NsService create: %v", err)
 	}
 
-	if resp.StatusCode != http.StatusCreated {
-		return fmt.Errorf("Unexpected status returned during NsService create: %v", resp.StatusCode)
-	}
 	d.SetId(nsService.Id)
 	return resourceNsxtIcmpTypeNsServiceRead(d, m)
 }

--- a/nsxt/resource_nsxt_igmp_type_ns_service.go
+++ b/nsxt/resource_nsxt_igmp_type_ns_service.go
@@ -83,13 +83,13 @@ func resourceNsxtIgmpTypeNsServiceRead(d *schema.ResourceData, m interface{}) er
 	}
 
 	nsService, resp, err := nsxClient.GroupingObjectsApi.ReadIgmpTypeNSService(nsxClient.Context, id)
-	if err != nil {
-		return fmt.Errorf("Error during NsService read: %v", err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		log.Printf("[DEBUG] NsService %s not found", id)
 		d.SetId("")
 		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error during NsService read: %v", err)
 	}
 
 	d.Set("revision", nsService.Revision)

--- a/nsxt/resource_nsxt_ip_block.go
+++ b/nsxt/resource_nsxt_ip_block.go
@@ -81,13 +81,13 @@ func resourceNsxtIPBlockRead(d *schema.ResourceData, m interface{}) error {
 	}
 
 	ipBlock, resp, err := nsxClient.PoolManagementApi.ReadIpBlock(nsxClient.Context, id)
-	if err != nil {
-		return fmt.Errorf("Error during IpBlock read: %v", err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		log.Printf("[DEBUG] IpBlock %s not found", id)
 		d.SetId("")
 		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error during IpBlock read: %v", err)
 	}
 
 	d.Set("revision", ipBlock.Revision)

--- a/nsxt/resource_nsxt_ip_block_subnet.go
+++ b/nsxt/resource_nsxt_ip_block_subnet.go
@@ -128,13 +128,13 @@ func resourceNsxtIPBlockSubnetRead(d *schema.ResourceData, m interface{}) error 
 	}
 
 	ipBlockSubnet, resp, err := nsxClient.PoolManagementApi.ReadIpBlockSubnet(nsxClient.Context, id)
-	if err != nil {
-		return fmt.Errorf("Error during IpBlockSubnet read: %v", err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		log.Printf("[DEBUG] IpBlockSubnet %s not found", id)
 		d.SetId("")
 		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error during IpBlockSubnet read: %v", err)
 	}
 
 	d.Set("display_name", ipBlockSubnet.DisplayName)

--- a/nsxt/resource_nsxt_ip_discovery_switching_profile.go
+++ b/nsxt/resource_nsxt_ip_discovery_switching_profile.go
@@ -108,15 +108,15 @@ func resourceNsxtIPDiscoverySwitchingProfileRead(d *schema.ResourceData, m inter
 	}
 
 	switchingProfile, resp, err := nsxClient.LogicalSwitchingApi.GetIpDiscoverySwitchingProfile(nsxClient.Context, id)
-	if err != nil {
-		return fmt.Errorf("Error during IPDiscoverySwitchingProfile read: %v", err)
-	}
-
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		log.Printf("[DEBUG] IPDiscoverySwitchingProfile %s not found", id)
 		d.SetId("")
 		return nil
 	}
+	if err != nil {
+		return fmt.Errorf("Error during IPDiscoverySwitchingProfile read: %v", err)
+	}
+
 	d.Set("revision", switchingProfile.Revision)
 	d.Set("description", switchingProfile.Description)
 	d.Set("display_name", switchingProfile.DisplayName)

--- a/nsxt/resource_nsxt_ip_pool.go
+++ b/nsxt/resource_nsxt_ip_pool.go
@@ -184,13 +184,13 @@ func resourceNsxtIPPoolRead(d *schema.ResourceData, m interface{}) error {
 	}
 
 	ipPool, resp, err := nsxClient.PoolManagementApi.ReadIpPool(nsxClient.Context, id)
-	if err != nil {
-		return fmt.Errorf("Error during IpPool read: %v", err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		log.Printf("[DEBUG] IpPool %s not found", id)
 		d.SetId("")
 		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error during IpPool read: %v", err)
 	}
 
 	d.Set("display_name", ipPool.DisplayName)

--- a/nsxt/resource_nsxt_ip_protocol_ns_service.go
+++ b/nsxt/resource_nsxt_ip_protocol_ns_service.go
@@ -92,13 +92,13 @@ func resourceNsxtIPProtocolNsServiceRead(d *schema.ResourceData, m interface{}) 
 	}
 
 	nsService, resp, err := nsxClient.GroupingObjectsApi.ReadIpProtocolNSService(nsxClient.Context, id)
-	if err != nil {
-		return fmt.Errorf("Error during NsService read: %v", err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		log.Printf("[DEBUG] NsService %s not found", id)
 		d.SetId("")
 		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error during NsService read: %v", err)
 	}
 
 	nsserviceElement := nsService.NsserviceElement

--- a/nsxt/resource_nsxt_ip_set.go
+++ b/nsxt/resource_nsxt_ip_set.go
@@ -84,13 +84,13 @@ func resourceNsxtIPSetRead(d *schema.ResourceData, m interface{}) error {
 	}
 
 	ipSet, resp, err := nsxClient.GroupingObjectsApi.ReadIPSet(nsxClient.Context, id)
-	if err != nil {
-		return fmt.Errorf("Error during IpSet read: %v", err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		log.Printf("[DEBUG] IpSet %s not found", id)
 		d.SetId("")
 		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error during IpSet read: %v", err)
 	}
 
 	d.Set("revision", ipSet.Revision)

--- a/nsxt/resource_nsxt_l4_port_set_ns_service.go
+++ b/nsxt/resource_nsxt_l4_port_set_ns_service.go
@@ -116,13 +116,13 @@ func resourceNsxtL4PortSetNsServiceRead(d *schema.ResourceData, m interface{}) e
 	}
 
 	nsService, resp, err := nsxClient.GroupingObjectsApi.ReadL4PortSetNSService(nsxClient.Context, id)
-	if err != nil {
-		return fmt.Errorf("Error during NsService read: %v", err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		log.Printf("[DEBUG] NsService %s not found", id)
 		d.SetId("")
 		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error during NsService read: %v", err)
 	}
 
 	nsserviceElement := nsService.NsserviceElement

--- a/nsxt/resource_nsxt_lb_client_ssl_profile.go
+++ b/nsxt/resource_nsxt_lb_client_ssl_profile.go
@@ -104,15 +104,15 @@ func resourceNsxtLbClientSslProfileRead(d *schema.ResourceData, m interface{}) e
 	}
 
 	lbClientSslProfile, resp, err := nsxClient.ServicesApi.ReadLoadBalancerClientSslProfile(nsxClient.Context, id)
-	if err != nil {
-		return fmt.Errorf("Error during LbClientSslProfile read: %v", err)
-	}
-
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		log.Printf("[DEBUG] LbClientSslProfile %s not found", id)
 		d.SetId("")
 		return nil
 	}
+	if err != nil {
+		return fmt.Errorf("Error during LbClientSslProfile read: %v", err)
+	}
+
 	d.Set("revision", lbClientSslProfile.Revision)
 	d.Set("description", lbClientSslProfile.Description)
 	d.Set("display_name", lbClientSslProfile.DisplayName)

--- a/nsxt/resource_nsxt_lb_cookie_persistence_profile.go
+++ b/nsxt/resource_nsxt_lb_cookie_persistence_profile.go
@@ -213,15 +213,15 @@ func resourceNsxtLbCookiePersistenceProfileRead(d *schema.ResourceData, m interf
 	}
 
 	lbCookiePersistenceProfile, resp, err := nsxClient.ServicesApi.ReadLoadBalancerCookiePersistenceProfile(nsxClient.Context, id)
-	if err != nil {
-		return fmt.Errorf("Error during LbCookiePersistenceProfile read: %v", err)
-	}
-
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		log.Printf("[DEBUG] LbCookiePersistenceProfile %s not found", id)
 		d.SetId("")
 		return nil
 	}
+	if err != nil {
+		return fmt.Errorf("Error during LbCookiePersistenceProfile read: %v", err)
+	}
+
 	d.Set("revision", lbCookiePersistenceProfile.Revision)
 	d.Set("description", lbCookiePersistenceProfile.Description)
 	d.Set("display_name", lbCookiePersistenceProfile.DisplayName)

--- a/nsxt/resource_nsxt_lb_fast_tcp_application_profile.go
+++ b/nsxt/resource_nsxt_lb_fast_tcp_application_profile.go
@@ -100,15 +100,15 @@ func resourceNsxtLbFastTCPApplicationProfileRead(d *schema.ResourceData, m inter
 	}
 
 	lbFastTCPProfile, resp, err := nsxClient.ServicesApi.ReadLoadBalancerFastTcpProfile(nsxClient.Context, id)
-	if err != nil {
-		return fmt.Errorf("Error during LbFastTcpProfile read: %v", err)
-	}
-
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		log.Printf("[DEBUG] LbFastTcpProfile %s not found", id)
 		d.SetId("")
 		return nil
 	}
+	if err != nil {
+		return fmt.Errorf("Error during LbFastTcpProfile read: %v", err)
+	}
+
 	d.Set("revision", lbFastTCPProfile.Revision)
 	d.Set("description", lbFastTCPProfile.Description)
 	d.Set("display_name", lbFastTCPProfile.DisplayName)

--- a/nsxt/resource_nsxt_lb_fast_udp_application_profile.go
+++ b/nsxt/resource_nsxt_lb_fast_udp_application_profile.go
@@ -70,14 +70,13 @@ func resourceNsxtLbFastUDPApplicationProfileCreate(d *schema.ResourceData, m int
 	}
 
 	lbFastUDPProfile, resp, err := nsxClient.ServicesApi.CreateLoadBalancerFastUdpProfile(nsxClient.Context, lbFastUDPProfile)
-
+	if resp != nil && resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("Unexpected status returned during LbFastUdpProfile create: %v", resp.StatusCode)
+	}
 	if err != nil {
 		return fmt.Errorf("Error during LbFastUdpProfile create: %v", err)
 	}
 
-	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("Unexpected status returned during LbFastUdpProfile create: %v", resp.StatusCode)
-	}
 	d.SetId(lbFastUDPProfile.Id)
 
 	return resourceNsxtLbFastUDPApplicationProfileRead(d, m)

--- a/nsxt/resource_nsxt_lb_http_application_profile.go
+++ b/nsxt/resource_nsxt_lb_http_application_profile.go
@@ -141,15 +141,15 @@ func resourceNsxtLbHTTPApplicationProfileRead(d *schema.ResourceData, m interfac
 	}
 
 	lbHTTPApplicationProfile, resp, err := nsxClient.ServicesApi.ReadLoadBalancerHttpProfile(nsxClient.Context, id)
-	if err != nil {
-		return fmt.Errorf("Error during LbHTTPApplicationProfile read: %v", err)
-	}
-
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		log.Printf("[DEBUG] LbHTTPApplicationProfile %s not found", id)
 		d.SetId("")
 		return nil
 	}
+	if err != nil {
+		return fmt.Errorf("Error during LbHTTPApplicationProfile read: %v", err)
+	}
+
 	d.Set("revision", lbHTTPApplicationProfile.Revision)
 	d.Set("description", lbHTTPApplicationProfile.Description)
 	d.Set("display_name", lbHTTPApplicationProfile.DisplayName)

--- a/nsxt/resource_nsxt_lb_http_forwarding_rule.go
+++ b/nsxt/resource_nsxt_lb_http_forwarding_rule.go
@@ -434,15 +434,15 @@ func resourceNsxtLbHTTPForwardingRuleRead(d *schema.ResourceData, m interface{})
 	}
 
 	lbRule, resp, err := nsxClient.ServicesApi.ReadLoadBalancerRule(nsxClient.Context, id)
-	if err != nil {
-		return fmt.Errorf("Error during LoadBalancerRule read: %v", err)
-	}
-
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		log.Printf("[DEBUG] LoadBalancerRule %s not found", id)
 		d.SetId("")
 		return nil
 	}
+	if err != nil {
+		return fmt.Errorf("Error during LoadBalancerRule read: %v", err)
+	}
+
 	d.Set("revision", lbRule.Revision)
 	d.Set("description", lbRule.Description)
 	d.Set("display_name", lbRule.DisplayName)

--- a/nsxt/resource_nsxt_lb_http_monitor.go
+++ b/nsxt/resource_nsxt_lb_http_monitor.go
@@ -109,13 +109,13 @@ func resourceNsxtLbHTTPMonitorRead(d *schema.ResourceData, m interface{}) error 
 	}
 
 	lbHTTPMonitor, resp, err := nsxClient.ServicesApi.ReadLoadBalancerHttpMonitor(nsxClient.Context, id)
-	if err != nil {
-		return fmt.Errorf("Error during LbHttpMonitor read: %v", err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		log.Printf("[DEBUG] LbHttpMonitor %s not found", id)
 		d.SetId("")
 		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error during LbHttpMonitor read: %v", err)
 	}
 
 	d.Set("revision", lbHTTPMonitor.Revision)

--- a/nsxt/resource_nsxt_lb_http_request_rewrite_rule.go
+++ b/nsxt/resource_nsxt_lb_http_request_rewrite_rule.go
@@ -387,15 +387,15 @@ func resourceNsxtLbHTTPRequestRewriteRuleRead(d *schema.ResourceData, m interfac
 	}
 
 	lbRule, resp, err := nsxClient.ServicesApi.ReadLoadBalancerRule(nsxClient.Context, id)
-	if err != nil {
-		return fmt.Errorf("Error during LoadBalancerRule read: %v", err)
-	}
-
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		log.Printf("[DEBUG] LoadBalancerRule %s not found", id)
 		d.SetId("")
 		return nil
 	}
+	if err != nil {
+		return fmt.Errorf("Error during LoadBalancerRule read: %v", err)
+	}
+
 	d.Set("revision", lbRule.Revision)
 	d.Set("description", lbRule.Description)
 	d.Set("display_name", lbRule.DisplayName)

--- a/nsxt/resource_nsxt_lb_http_response_rewrite_rule.go
+++ b/nsxt/resource_nsxt_lb_http_response_rewrite_rule.go
@@ -351,15 +351,15 @@ func resourceNsxtLbHTTPResponseRewriteRuleRead(d *schema.ResourceData, m interfa
 	}
 
 	lbRule, resp, err := nsxClient.ServicesApi.ReadLoadBalancerRule(nsxClient.Context, id)
-	if err != nil {
-		return fmt.Errorf("Error during LoadBalancerRule read: %v", err)
-	}
-
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		log.Printf("[DEBUG] LoadBalancerRule %s not found", id)
 		d.SetId("")
 		return nil
 	}
+	if err != nil {
+		return fmt.Errorf("Error during LoadBalancerRule read: %v", err)
+	}
+
 	d.Set("revision", lbRule.Revision)
 	d.Set("description", lbRule.Description)
 	d.Set("display_name", lbRule.DisplayName)

--- a/nsxt/resource_nsxt_lb_http_virtual_server.go
+++ b/nsxt/resource_nsxt_lb_http_virtual_server.go
@@ -335,15 +335,15 @@ func resourceNsxtLbHTTPVirtualServerRead(d *schema.ResourceData, m interface{}) 
 	}
 
 	lbVirtualServer, resp, err := nsxClient.ServicesApi.ReadLoadBalancerVirtualServer(nsxClient.Context, id)
-	if err != nil {
-		return fmt.Errorf("Error during LbVirtualServer read: %v", err)
-	}
-
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		log.Printf("[DEBUG] LbVirtualServer %s not found", id)
 		d.SetId("")
 		return nil
 	}
+	if err != nil {
+		return fmt.Errorf("Error during LbVirtualServer read: %v", err)
+	}
+
 	d.Set("revision", lbVirtualServer.Revision)
 	d.Set("description", lbVirtualServer.Description)
 	d.Set("display_name", lbVirtualServer.DisplayName)

--- a/nsxt/resource_nsxt_lb_https_monitor.go
+++ b/nsxt/resource_nsxt_lb_https_monitor.go
@@ -144,13 +144,13 @@ func resourceNsxtLbHTTPSMonitorRead(d *schema.ResourceData, m interface{}) error
 	}
 
 	lbHTTPSMonitor, resp, err := nsxClient.ServicesApi.ReadLoadBalancerHttpsMonitor(nsxClient.Context, id)
-	if err != nil {
-		return fmt.Errorf("Error during LbHttpsMonitor read: %v", err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		log.Printf("[DEBUG] LbHttpsMonitor %s not found", id)
 		d.SetId("")
 		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error during LbHttpsMonitor read: %v", err)
 	}
 
 	d.Set("revision", lbHTTPSMonitor.Revision)

--- a/nsxt/resource_nsxt_lb_icmp_monitor.go
+++ b/nsxt/resource_nsxt_lb_icmp_monitor.go
@@ -77,14 +77,13 @@ func resourceNsxtLbIcmpMonitorCreate(d *schema.ResourceData, m interface{}) erro
 	}
 
 	lbIcmpMonitor, resp, err := nsxClient.ServicesApi.CreateLoadBalancerIcmpMonitor(nsxClient.Context, lbIcmpMonitor)
-
+	if resp != nil && resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("Unexpected status returned during LbMonitor create: %v", resp.StatusCode)
+	}
 	if err != nil {
 		return fmt.Errorf("Error during LbMonitor create: %v", err)
 	}
 
-	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("Unexpected status returned during LbMonitor create: %v", resp.StatusCode)
-	}
 	d.SetId(lbIcmpMonitor.Id)
 
 	return resourceNsxtLbIcmpMonitorRead(d, m)

--- a/nsxt/resource_nsxt_lb_passive_monitor.go
+++ b/nsxt/resource_nsxt_lb_passive_monitor.go
@@ -89,13 +89,13 @@ func resourceNsxtLbPassiveMonitorRead(d *schema.ResourceData, m interface{}) err
 	}
 
 	lbPassiveMonitor, resp, err := nsxClient.ServicesApi.ReadLoadBalancerPassiveMonitor(nsxClient.Context, id)
-	if err != nil {
-		return fmt.Errorf("Error during LbMonitor read: %v", err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		log.Printf("[DEBUG] LbMonitor %s not found", id)
 		d.SetId("")
 		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error during LbMonitor read: %v", err)
 	}
 
 	d.Set("revision", lbPassiveMonitor.Revision)

--- a/nsxt/resource_nsxt_lb_pool.go
+++ b/nsxt/resource_nsxt_lb_pool.go
@@ -396,13 +396,13 @@ func resourceNsxtLbPoolRead(d *schema.ResourceData, m interface{}) error {
 	}
 
 	lbPool, resp, err := nsxClient.ServicesApi.ReadLoadBalancerPool(nsxClient.Context, id)
-	if err != nil {
-		return fmt.Errorf("Error during LbPool read: %v", err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		log.Printf("[DEBUG] LbPool %s not found", id)
 		d.SetId("")
 		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error during LbPool read: %v", err)
 	}
 
 	d.Set("revision", lbPool.Revision)

--- a/nsxt/resource_nsxt_lb_server_ssl_profile.go
+++ b/nsxt/resource_nsxt_lb_server_ssl_profile.go
@@ -88,15 +88,15 @@ func resourceNsxtLbServerSslProfileRead(d *schema.ResourceData, m interface{}) e
 	}
 
 	lbServerSslProfile, resp, err := nsxClient.ServicesApi.ReadLoadBalancerServerSslProfile(nsxClient.Context, id)
-	if err != nil {
-		return fmt.Errorf("Error during LbServerSslProfile read: %v", err)
-	}
-
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		log.Printf("[DEBUG] LbServerSslProfile %s not found", id)
 		d.SetId("")
 		return nil
 	}
+	if err != nil {
+		return fmt.Errorf("Error during LbServerSslProfile read: %v", err)
+	}
+
 	d.Set("revision", lbServerSslProfile.Revision)
 	d.Set("description", lbServerSslProfile.Description)
 	d.Set("display_name", lbServerSslProfile.DisplayName)

--- a/nsxt/resource_nsxt_lb_service.go
+++ b/nsxt/resource_nsxt_lb_service.go
@@ -124,13 +124,13 @@ func resourceNsxtLbServiceRead(d *schema.ResourceData, m interface{}) error {
 	}
 
 	lbService, resp, err := nsxClient.ServicesApi.ReadLoadBalancerService(nsxClient.Context, id)
-	if err != nil {
-		return fmt.Errorf("Error during LbService read: %v", err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		log.Printf("[DEBUG] LbService %s not found", id)
 		d.SetId("")
 		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error during LbService read: %v", err)
 	}
 
 	d.Set("revision", lbService.Revision)

--- a/nsxt/resource_nsxt_lb_source_ip_persistence_profile.go
+++ b/nsxt/resource_nsxt_lb_source_ip_persistence_profile.go
@@ -108,15 +108,15 @@ func resourceNsxtLbSourceIPPersistenceProfileRead(d *schema.ResourceData, m inte
 	}
 
 	lbSourceIPPersistenceProfile, resp, err := nsxClient.ServicesApi.ReadLoadBalancerSourceIpPersistenceProfile(nsxClient.Context, id)
-	if err != nil {
-		return fmt.Errorf("Error during LbSourceIPPersistenceProfile read: %v", err)
-	}
-
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		log.Printf("[DEBUG] LbSourceIPPersistenceProfile %s not found", id)
 		d.SetId("")
 		return nil
 	}
+	if err != nil {
+		return fmt.Errorf("Error during LbSourceIPPersistenceProfile read: %v", err)
+	}
+
 	d.Set("revision", lbSourceIPPersistenceProfile.Revision)
 	d.Set("description", lbSourceIPPersistenceProfile.Description)
 	d.Set("display_name", lbSourceIPPersistenceProfile.DisplayName)

--- a/nsxt/resource_nsxt_lb_tcp_monitor.go
+++ b/nsxt/resource_nsxt_lb_tcp_monitor.go
@@ -73,13 +73,13 @@ func resourceNsxtLbTCPMonitorRead(d *schema.ResourceData, m interface{}) error {
 	}
 
 	lbTCPMonitor, resp, err := nsxClient.ServicesApi.ReadLoadBalancerTcpMonitor(nsxClient.Context, id)
-	if err != nil {
-		return fmt.Errorf("Error during LbMonitor read: %v", err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		log.Printf("[DEBUG] LbMonitor %s not found", id)
 		d.SetId("")
 		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error during LbMonitor read: %v", err)
 	}
 
 	d.Set("revision", lbTCPMonitor.Revision)

--- a/nsxt/resource_nsxt_lb_tcp_virtual_server.go
+++ b/nsxt/resource_nsxt_lb_tcp_virtual_server.go
@@ -163,15 +163,15 @@ func resourceNsxtLbTCPVirtualServerRead(d *schema.ResourceData, m interface{}) e
 	}
 
 	lbVirtualServer, resp, err := nsxClient.ServicesApi.ReadLoadBalancerVirtualServer(nsxClient.Context, id)
-	if err != nil {
-		return fmt.Errorf("Error during LbVirtualServer read: %v", err)
-	}
-
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		log.Printf("[DEBUG] LbVirtualServer %s not found", id)
 		d.SetId("")
 		return nil
 	}
+	if err != nil {
+		return fmt.Errorf("Error during LbVirtualServer read: %v", err)
+	}
+
 	d.Set("revision", lbVirtualServer.Revision)
 	d.Set("description", lbVirtualServer.Description)
 	d.Set("display_name", lbVirtualServer.DisplayName)

--- a/nsxt/resource_nsxt_lb_udp_monitor.go
+++ b/nsxt/resource_nsxt_lb_udp_monitor.go
@@ -73,13 +73,13 @@ func resourceNsxtLbUDPMonitorRead(d *schema.ResourceData, m interface{}) error {
 	}
 
 	lbUDPMonitor, resp, err := nsxClient.ServicesApi.ReadLoadBalancerUdpMonitor(nsxClient.Context, id)
-	if err != nil {
-		return fmt.Errorf("Error during LbMonitor read: %v", err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		log.Printf("[DEBUG] LbMonitor %s not found", id)
 		d.SetId("")
 		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error during LbMonitor read: %v", err)
 	}
 
 	d.Set("revision", lbUDPMonitor.Revision)

--- a/nsxt/resource_nsxt_lb_udp_virtual_server.go
+++ b/nsxt/resource_nsxt_lb_udp_virtual_server.go
@@ -163,15 +163,15 @@ func resourceNsxtLbUDPVirtualServerRead(d *schema.ResourceData, m interface{}) e
 	}
 
 	lbVirtualServer, resp, err := nsxClient.ServicesApi.ReadLoadBalancerVirtualServer(nsxClient.Context, id)
-	if err != nil {
-		return fmt.Errorf("Error during LbVirtualServer read: %v", err)
-	}
-
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		log.Printf("[DEBUG] LbVirtualServer %s not found", id)
 		d.SetId("")
 		return nil
 	}
+	if err != nil {
+		return fmt.Errorf("Error during LbVirtualServer read: %v", err)
+	}
+
 	d.Set("revision", lbVirtualServer.Revision)
 	d.Set("description", lbVirtualServer.Description)
 	d.Set("display_name", lbVirtualServer.DisplayName)

--- a/nsxt/resource_nsxt_logical_dhcp_port.go
+++ b/nsxt/resource_nsxt_logical_dhcp_port.go
@@ -97,15 +97,15 @@ func resourceNsxtLogicalDhcpPortRead(d *schema.ResourceData, m interface{}) erro
 		return fmt.Errorf("Error obtaining logical DHCP port ID from state during read")
 	}
 	LogicalDhcpPort, resp, err := nsxClient.LogicalSwitchingApi.GetLogicalPort(nsxClient.Context, id)
-
-	if err != nil {
-		return fmt.Errorf("Error while reading logical DHCP port %s: %v", id, err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		d.SetId("")
 		log.Printf("[DEBUG] Logical DHCP port %s not found", id)
 		return nil
 	}
+	if err != nil {
+		return fmt.Errorf("Error while reading logical DHCP port %s: %v", id, err)
+	}
+
 	if LogicalDhcpPort.Attachment == nil || LogicalDhcpPort.Attachment.AttachmentType != dhcpType {
 		return fmt.Errorf("Error reading DHCP port %s: This not a DHCP port", id)
 	}

--- a/nsxt/resource_nsxt_logical_dhcp_server.go
+++ b/nsxt/resource_nsxt_logical_dhcp_server.go
@@ -235,13 +235,13 @@ func resourceNsxtLogicalDhcpServerRead(d *schema.ResourceData, m interface{}) er
 	}
 
 	logicalDhcpServer, resp, err := nsxClient.ServicesApi.ReadDhcpServer(nsxClient.Context, id)
-	if err != nil {
-		return fmt.Errorf("Error during LogicalDhcpServer read: %v", err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		log.Printf("[DEBUG] LogicalDhcpServer %s not found", id)
 		d.SetId("")
 		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error during LogicalDhcpServer read: %v", err)
 	}
 
 	d.Set("revision", logicalDhcpServer.Revision)

--- a/nsxt/resource_nsxt_logical_port.go
+++ b/nsxt/resource_nsxt_logical_port.go
@@ -87,14 +87,13 @@ func resourceNsxtLogicalPortRead(d *schema.ResourceData, m interface{}) error {
 		return fmt.Errorf("Error obtaining logical port ID from state during read")
 	}
 	logicalPort, resp, err := nsxClient.LogicalSwitchingApi.GetLogicalPort(nsxClient.Context, id)
-
-	if err != nil {
-		return fmt.Errorf("Error while reading logical port %s: %v", id, err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		d.SetId("")
 		log.Printf("[DEBUG] Logical port %s not found", id)
 		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error while reading logical port %s: %v", id, err)
 	}
 
 	d.Set("revision", logicalPort.Revision)

--- a/nsxt/resource_nsxt_logical_router_centralized_service_port.go
+++ b/nsxt/resource_nsxt_logical_router_centralized_service_port.go
@@ -107,13 +107,13 @@ func resourceNsxtLogicalRouterCentralizedServicePortRead(d *schema.ResourceData,
 	}
 
 	LogicalRouterCentralizedServicePort, resp, err := nsxClient.LogicalRoutingAndServicesApi.ReadLogicalRouterCentralizedServicePort(nsxClient.Context, id)
-	if err != nil {
-		return fmt.Errorf("Error during LogicalRouterCentralizedServicePort read: %v", err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		log.Printf("[DEBUG] LogicalRouterCentralizedServicePort %s not found", id)
 		d.SetId("")
 		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error during LogicalRouterCentralizedServicePort read: %v", err)
 	}
 
 	d.Set("revision", LogicalRouterCentralizedServicePort.Revision)

--- a/nsxt/resource_nsxt_logical_router_downlink_port.go
+++ b/nsxt/resource_nsxt_logical_router_downlink_port.go
@@ -142,13 +142,13 @@ func resourceNsxtLogicalRouterDownLinkPortRead(d *schema.ResourceData, m interfa
 	}
 
 	logicalRouterDownLinkPort, resp, err := nsxClient.LogicalRoutingAndServicesApi.ReadLogicalRouterDownLinkPort(nsxClient.Context, id)
-	if err != nil {
-		return fmt.Errorf("Error during LogicalRouterDownLinkPort read: %v", err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		log.Printf("[DEBUG] LogicalRouterDownLinkPort %s not found", id)
 		d.SetId("")
 		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error during LogicalRouterDownLinkPort read: %v", err)
 	}
 
 	d.Set("revision", logicalRouterDownLinkPort.Revision)

--- a/nsxt/resource_nsxt_logical_router_link_port_on_tier0.go
+++ b/nsxt/resource_nsxt_logical_router_link_port_on_tier0.go
@@ -87,13 +87,13 @@ func resourceNsxtLogicalRouterLinkPortOnTier0Read(d *schema.ResourceData, m inte
 	}
 
 	logicalRouterLinkPort, resp, err := nsxClient.LogicalRoutingAndServicesApi.ReadLogicalRouterLinkPortOnTier0(nsxClient.Context, id)
-	if err != nil {
-		return fmt.Errorf("Error during LogicalRouterLinkPortOnTier0 read: %v", err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		log.Printf("[DEBUG] LogicalRouterLinkPortOnTier0 %s not found", id)
 		d.SetId("")
 		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error during LogicalRouterLinkPortOnTier0 read: %v", err)
 	}
 
 	d.Set("revision", logicalRouterLinkPort.Revision)

--- a/nsxt/resource_nsxt_logical_router_link_port_on_tier1.go
+++ b/nsxt/resource_nsxt_logical_router_link_port_on_tier1.go
@@ -68,14 +68,13 @@ func resourceNsxtLogicalRouterLinkPortOnTier1Create(d *schema.ResourceData, m in
 	}
 
 	logicalRouterLinkPort, resp, err := nsxClient.LogicalRoutingAndServicesApi.CreateLogicalRouterLinkPortOnTier1(nsxClient.Context, logicalRouterLinkPort)
-
+	if resp != nil && resp.StatusCode != http.StatusCreated {
+		return fmt.Errorf("Unexpected status returned during LogicalRouterLinkPortOnTier1 create: %v", resp.StatusCode)
+	}
 	if err != nil {
 		return fmt.Errorf("Error during LogicalRouterLinkPortOnTier1 create: %v", err)
 	}
 
-	if resp.StatusCode != http.StatusCreated {
-		return fmt.Errorf("Unexpected status returned during LogicalRouterLinkPortOnTier1 create: %v", resp.StatusCode)
-	}
 	d.SetId(logicalRouterLinkPort.Id)
 
 	return resourceNsxtLogicalRouterLinkPortOnTier1Read(d, m)
@@ -89,13 +88,13 @@ func resourceNsxtLogicalRouterLinkPortOnTier1Read(d *schema.ResourceData, m inte
 	}
 
 	logicalRouterLinkPort, resp, err := nsxClient.LogicalRoutingAndServicesApi.ReadLogicalRouterLinkPortOnTier1(nsxClient.Context, id)
-	if err != nil {
-		return fmt.Errorf("Error during LogicalRouterLinkPortOnTier1 read: %v", err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		log.Printf("[DEBUG] LogicalRouterLinkPortOnTier1 %s not found", id)
 		d.SetId("")
 		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error during LogicalRouterLinkPortOnTier1 read: %v", err)
 	}
 
 	d.Set("revision", logicalRouterLinkPort.Revision)

--- a/nsxt/resource_nsxt_logical_switch.go
+++ b/nsxt/resource_nsxt_logical_switch.go
@@ -198,13 +198,13 @@ func resourceNsxtLogicalSwitchRead(d *schema.ResourceData, m interface{}) error 
 	}
 
 	logicalSwitch, resp, err := nsxClient.LogicalSwitchingApi.GetLogicalSwitch(nsxClient.Context, id)
-	if err != nil {
-		return fmt.Errorf("Error during LogicalSwitch read: %v", err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		log.Printf("[DEBUG] LogicalSwitch %s not found", id)
 		d.SetId("")
 		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error during LogicalSwitch read: %v", err)
 	}
 
 	err = resourceNsxtLogicalSwitchVerifyRealization(d, nsxClient, &logicalSwitch)

--- a/nsxt/resource_nsxt_logical_tier0_router.go
+++ b/nsxt/resource_nsxt_logical_tier0_router.go
@@ -109,13 +109,13 @@ func resourceNsxtLogicalTier0RouterRead(d *schema.ResourceData, m interface{}) e
 	}
 
 	logicalRouter, resp, err := nsxClient.LogicalRoutingAndServicesApi.ReadLogicalRouter(nsxClient.Context, id)
-	if err != nil {
-		return fmt.Errorf("Error during LogicalTier0Router read: %v", err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		log.Printf("[DEBUG] LogicalTier0Router %s not found", id)
 		d.SetId("")
 		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error during LogicalTier0Router read: %v", err)
 	}
 
 	d.Set("revision", logicalRouter.Revision)

--- a/nsxt/resource_nsxt_logical_tier1_router.go
+++ b/nsxt/resource_nsxt_logical_tier1_router.go
@@ -226,13 +226,13 @@ func resourceNsxtLogicalTier1RouterRead(d *schema.ResourceData, m interface{}) e
 	}
 
 	logicalRouter, resp, err := nsxClient.LogicalRoutingAndServicesApi.ReadLogicalRouter(nsxClient.Context, id)
-	if err != nil {
-		return fmt.Errorf("Error during LogicalTier1Router read: %v", err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		log.Printf("[DEBUG] LogicalTier1Router %s not found", id)
 		d.SetId("")
 		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error during LogicalTier1Router read: %v", err)
 	}
 
 	d.Set("revision", logicalRouter.Revision)

--- a/nsxt/resource_nsxt_mac_management_switching_profile.go
+++ b/nsxt/resource_nsxt_mac_management_switching_profile.go
@@ -150,15 +150,15 @@ func resourceNsxtMacManagementSwitchingProfileRead(d *schema.ResourceData, m int
 	}
 
 	switchingProfile, resp, err := nsxClient.LogicalSwitchingApi.GetMacManagementSwitchingProfile(nsxClient.Context, id)
-	if err != nil {
-		return fmt.Errorf("Error during MacManagementSwitchingProfile read: %v", err)
-	}
-
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		log.Printf("[DEBUG] MacManagementSwitchingProfile %s not found", id)
 		d.SetId("")
 		return nil
 	}
+	if err != nil {
+		return fmt.Errorf("Error during MacManagementSwitchingProfile read: %v", err)
+	}
+
 	d.Set("revision", switchingProfile.Revision)
 	d.Set("description", switchingProfile.Description)
 	d.Set("display_name", switchingProfile.DisplayName)

--- a/nsxt/resource_nsxt_ns_group.go
+++ b/nsxt/resource_nsxt_ns_group.go
@@ -196,16 +196,15 @@ func resourceNsxtNsGroupRead(d *schema.ResourceData, m interface{}) error {
 
 	localVarOptionals := make(map[string]interface{})
 	localVarOptionals["populateReferences"] = true
+
 	nsGroup, resp, err := nsxClient.GroupingObjectsApi.ReadNSGroup(nsxClient.Context, id, localVarOptionals)
-
-	if err != nil {
-		return fmt.Errorf("Error during NsGroup read: %v", err)
-	}
-
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		log.Printf("[DEBUG] NsGroup %s not found", id)
 		d.SetId("")
 		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error during NsGroup read: %v", err)
 	}
 
 	d.Set("revision", nsGroup.Revision)

--- a/nsxt/resource_nsxt_ns_service_group.go
+++ b/nsxt/resource_nsxt_ns_service_group.go
@@ -107,15 +107,15 @@ func resourceNsxtNsServiceGroupRead(d *schema.ResourceData, m interface{}) error
 	}
 
 	nsServiceGroup, resp, err := nsxClient.GroupingObjectsApi.ReadNSServiceGroup(nsxClient.Context, id)
-	if err != nil {
-		return fmt.Errorf("Error during NsServiceGroup read: %v", err)
-	}
-
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		log.Printf("[DEBUG] NsServiceGroup %s not found", id)
 		d.SetId("")
 		return nil
 	}
+	if err != nil {
+		return fmt.Errorf("Error during NsServiceGroup read: %v", err)
+	}
+
 	d.Set("revision", nsServiceGroup.Revision)
 	d.Set("description", nsServiceGroup.Description)
 	d.Set("display_name", nsServiceGroup.DisplayName)

--- a/nsxt/resource_nsxt_qos_switching_profile.go
+++ b/nsxt/resource_nsxt_qos_switching_profile.go
@@ -227,15 +227,15 @@ func resourceNsxtQosSwitchingProfileRead(d *schema.ResourceData, m interface{}) 
 	}
 
 	qosSwitchingProfile, resp, err := nsxClient.LogicalSwitchingApi.GetQosSwitchingProfile(nsxClient.Context, id)
-	if err != nil {
-		return fmt.Errorf("Error during QosSwitchingProfile read: %v", err)
-	}
-
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		log.Printf("[DEBUG] QosSwitchingProfile %s not found", id)
 		d.SetId("")
 		return nil
 	}
+	if err != nil {
+		return fmt.Errorf("Error during QosSwitchingProfile read: %v", err)
+	}
+
 	d.Set("revision", qosSwitchingProfile.Revision)
 	d.Set("description", qosSwitchingProfile.Description)
 	d.Set("display_name", qosSwitchingProfile.DisplayName)

--- a/nsxt/resource_nsxt_spoofguard_switching_profile.go
+++ b/nsxt/resource_nsxt_spoofguard_switching_profile.go
@@ -85,15 +85,15 @@ func resourceNsxtSpoofGuardSwitchingProfileRead(d *schema.ResourceData, m interf
 	}
 
 	sgSwitchingProfile, resp, err := nsxClient.LogicalSwitchingApi.GetSpoofGuardSwitchingProfile(nsxClient.Context, id)
-	if err != nil {
-		return fmt.Errorf("Error during SpoofGuardSwitchingProfile read: %v", err)
-	}
-
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		log.Printf("[DEBUG] SpoofGuardSwitchingProfile %s not found", id)
 		d.SetId("")
 		return nil
 	}
+	if err != nil {
+		return fmt.Errorf("Error during SpoofGuardSwitchingProfile read: %v", err)
+	}
+
 	d.Set("revision", sgSwitchingProfile.Revision)
 	d.Set("description", sgSwitchingProfile.Description)
 	d.Set("display_name", sgSwitchingProfile.DisplayName)

--- a/nsxt/resource_nsxt_static_route.go
+++ b/nsxt/resource_nsxt_static_route.go
@@ -182,13 +182,13 @@ func resourceNsxtStaticRouteRead(d *schema.ResourceData, m interface{}) error {
 	}
 
 	staticRoute, resp, err := nsxClient.LogicalRoutingAndServicesApi.ReadStaticRoute(nsxClient.Context, logicalRouterID, id)
-	if err != nil {
-		return fmt.Errorf("Error during StaticRoute read: %v", err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		log.Printf("[DEBUG] StaticRoute %s not found", id)
 		d.SetId("")
 		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error during StaticRoute read: %v", err)
 	}
 
 	d.Set("revision", staticRoute.Revision)

--- a/nsxt/resource_nsxt_switch_security_switching_profile.go
+++ b/nsxt/resource_nsxt_switch_security_switching_profile.go
@@ -215,14 +215,13 @@ func resourceNsxtSwitchSecuritySwitchingProfileRead(d *schema.ResourceData, m in
 	}
 
 	switchSecurityProfile, resp, err := nsxClient.LogicalSwitchingApi.GetSwitchSecuritySwitchingProfile(nsxClient.Context, id)
-	if err != nil {
-		return fmt.Errorf("Error during SwitchSecurityProfile read: %v", err)
-	}
-
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		log.Printf("[DEBUG] SwitchSecurityProfile %s not found", id)
 		d.SetId("")
 		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error during SwitchSecurityProfile read: %v", err)
 	}
 
 	d.Set("revision", switchSecurityProfile.Revision)

--- a/nsxt/resource_nsxt_vlan_logical_switch.go
+++ b/nsxt/resource_nsxt_vlan_logical_switch.go
@@ -120,13 +120,13 @@ func resourceNsxtVlanLogicalSwitchRead(d *schema.ResourceData, m interface{}) er
 	}
 
 	logicalSwitch, resp, err := nsxClient.LogicalSwitchingApi.GetLogicalSwitch(nsxClient.Context, id)
-	if err != nil {
-		return fmt.Errorf("Error during LogicalSwitch read: %v", err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		log.Printf("[DEBUG] LogicalSwitch %s not found", id)
 		d.SetId("")
 		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error during LogicalSwitch read: %v", err)
 	}
 
 	d.Set("revision", logicalSwitch.Revision)


### PR DESCRIPTION
The nsxt resources do not behave correctly during the refresh cycle,
if the described resource has vanished. Here an error 404 is reported
and terraform stops processing (instead of recreating the missing resource).

This is caused by a general implementation error in nearly all
resources based on a wrong assumption about the behaviour of the go SDK.
It assumes that http status codes are never reported as errors, but
all the SDK functions return an error if the status code is above 300.
Therefore the order of the error handling in the read functions of
the resources is wrong.

Instead of

```
if err != nil {
  return fmt.Errorf("Error during LogicalSwitch read: %v", err)
}
if resp.StatusCode == http.StatusNotFound {
  log.Printf("[DEBUG] LogicalSwitch %s not found", id)
  d.SetId("")
  return nil
}
```

the correct error handling must always be

```
if resp != nil && resp.StatusCode == http.StatusNotFound {
  log.Printf("[DEBUG] LogicalSwitch %s not found", id)
  d.SetId("")
  return nil
}
if err != nil {
  return fmt.Errorf("Error during LogicalSwitch read: %v", err)
}
```

In three cases the order was already fixed, but in two of these cases
the nil pointer check was missing, causing a NPE for http request
execution errors.