### PR TITLE
Fix error handling in data sources

### DIFF
--- a/nsxt/data_source_nsxt_certificate.go
+++ b/nsxt/data_source_nsxt_certificate.go
@@ -48,11 +48,11 @@ func dataSourceNsxtCertificateRead(d *schema.ResourceData, m interface{}) error 
 		// Get by id
 		objGet, resp, err := nsxClient.NsxComponentAdministrationApi.GetCertificate(nsxClient.Context, objID, nil)
 
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return fmt.Errorf("certificate %s was not found", objID)
+		}
 		if err != nil {
 			return fmt.Errorf("Error while reading certificate %s: %v", objID, err)
-		}
-		if resp.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("certificate %s was not found", objID)
 		}
 		obj = objGet
 
@@ -75,7 +75,7 @@ func dataSourceNsxtCertificateRead(d *schema.ResourceData, m interface{}) error 
 			}
 		}
 		if !found {
-			return fmt.Errorf("certificate '%s' was not found", objName)
+			return fmt.Errorf("Certificate with name '%s' was not found", objName)
 		}
 	} else {
 		return fmt.Errorf("Error obtaining certificate ID or name during read")

--- a/nsxt/data_source_nsxt_edge_cluster.go
+++ b/nsxt/data_source_nsxt_edge_cluster.go
@@ -61,13 +61,14 @@ func dataSourceNsxtEdgeClusterRead(d *schema.ResourceData, m interface{}) error 
 		// Get by id
 		objGet, resp, err := nsxClient.NetworkTransportApi.ReadEdgeCluster(nsxClient.Context, objID)
 
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return fmt.Errorf("Edge cluster %s was not found", objID)
+		}
 		if err != nil {
 			return fmt.Errorf("Error while reading edge cluster %s: %v", objID, err)
 		}
-		if resp.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("Edge cluster %s was not found", objID)
-		}
 		obj = objGet
+
 	} else if objName == "" {
 		return fmt.Errorf("Error obtaining edge cluster ID or name during read")
 	} else {
@@ -99,7 +100,7 @@ func dataSourceNsxtEdgeClusterRead(d *schema.ResourceData, m interface{}) error 
 			}
 			obj = prefixMatch[0]
 		} else {
-			return fmt.Errorf("Edge cluster '%s' was not found", objName)
+			return fmt.Errorf("Edge cluster with name '%s' was not found", objName)
 		}
 	}
 

--- a/nsxt/data_source_nsxt_logical_tier0_router.go
+++ b/nsxt/data_source_nsxt_logical_tier0_router.go
@@ -61,11 +61,11 @@ func dataSourceNsxtLogicalTier0RouterRead(d *schema.ResourceData, m interface{})
 		// Get by id
 		objGet, resp, err := nsxClient.LogicalRoutingAndServicesApi.ReadLogicalRouter(nsxClient.Context, objID)
 
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return fmt.Errorf("Logical tier0 router %s was not found", objID)
+		}
 		if err != nil {
 			return fmt.Errorf("Error while reading logical tier0 router %s: %v", objID, err)
-		}
-		if resp.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("Logical tier0 router %s was not found", objID)
 		}
 		if objGet.RouterType != "TIER0" {
 			return fmt.Errorf("Logical router %s is not a tier0 router", objID)
@@ -104,7 +104,7 @@ func dataSourceNsxtLogicalTier0RouterRead(d *schema.ResourceData, m interface{})
 			}
 			obj = prefixMatch[0]
 		} else {
-			return fmt.Errorf("Logical tier0 router '%s' was not found", objName)
+			return fmt.Errorf("Logical tier0 router with name '%s' was not found", objName)
 		}
 	}
 

--- a/nsxt/data_source_nsxt_logical_tier1_router.go
+++ b/nsxt/data_source_nsxt_logical_tier1_router.go
@@ -55,11 +55,11 @@ func dataSourceNsxtLogicalTier1RouterRead(d *schema.ResourceData, m interface{})
 		// Get by id
 		objGet, resp, err := nsxClient.LogicalRoutingAndServicesApi.ReadLogicalRouter(nsxClient.Context, objID)
 
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return fmt.Errorf("Logical tier1 router %s was not found", objID)
+		}
 		if err != nil {
 			return fmt.Errorf("Error while reading logical tier1 router %s: %v", objID, err)
-		}
-		if resp.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("Logical tier1 router %s was not found", objID)
 		}
 		if objGet.RouterType != "TIER1" {
 			return fmt.Errorf("Logical router %s is not a tier1 router", objID)
@@ -98,7 +98,7 @@ func dataSourceNsxtLogicalTier1RouterRead(d *schema.ResourceData, m interface{})
 			}
 			obj = prefixMatch[0]
 		} else {
-			return fmt.Errorf("Logical tier1 router '%s' was not found", objName)
+			return fmt.Errorf("Logical tier1 router with name '%s' was not found", objName)
 		}
 	}
 

--- a/nsxt/data_source_nsxt_mac_pool.go
+++ b/nsxt/data_source_nsxt_mac_pool.go
@@ -48,11 +48,11 @@ func dataSourceNsxtMacPoolRead(d *schema.ResourceData, m interface{}) error {
 		// Get by id
 		objGet, resp, err := nsxClient.PoolManagementApi.ReadMacPool(nsxClient.Context, objID)
 
-		if err != nil {
-			return fmt.Errorf("Error while reading ns service %s: %v", objID, err)
-		}
-		if resp.StatusCode == http.StatusNotFound {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
 			return fmt.Errorf("Mac pool %s was not found", objID)
+		}
+		if err != nil {
+			return fmt.Errorf("Error while reading Mac pool %s: %v", objID, err)
 		}
 		obj = objGet
 	} else if objName != "" {
@@ -74,7 +74,7 @@ func dataSourceNsxtMacPoolRead(d *schema.ResourceData, m interface{}) error {
 			}
 		}
 		if !found {
-			return fmt.Errorf("Mac pool '%s' was not found out of %d services", objName, len(objList.Results))
+			return fmt.Errorf("Mac pool with name '%s' was not found among %d pools", objName, len(objList.Results))
 		}
 	} else {
 		return fmt.Errorf("Error obtaining Mac pool ID or name during read")

--- a/nsxt/data_source_nsxt_ns_group.go
+++ b/nsxt/data_source_nsxt_ns_group.go
@@ -50,11 +50,11 @@ func dataSourceNsxtNsGroupRead(d *schema.ResourceData, m interface{}) error {
 		localVarOptionals["populateReferences"] = true
 		objGet, resp, err := nsxClient.GroupingObjectsApi.ReadNSGroup(nsxClient.Context, objID, localVarOptionals)
 
-		if err != nil {
-			return fmt.Errorf("Error while reading ns group %s: %v", objID, err)
-		}
-		if resp.StatusCode == http.StatusNotFound {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
 			return fmt.Errorf("NS group %s was not found", objID)
+		}
+		if err != nil {
+			return fmt.Errorf("Error while reading NS group %s: %v", objID, err)
 		}
 		obj = objGet
 	} else if objName != "" {
@@ -76,7 +76,7 @@ func dataSourceNsxtNsGroupRead(d *schema.ResourceData, m interface{}) error {
 			}
 		}
 		if !found {
-			return fmt.Errorf("NS group '%s' was not found out of %d groups", objName, len(objList.Results))
+			return fmt.Errorf("NS group with  name '%s' was not found among %d groups", objName, len(objList.Results))
 		}
 	} else {
 		return fmt.Errorf("Error obtaining NS group ID or name during read")

--- a/nsxt/data_source_nsxt_ns_service.go
+++ b/nsxt/data_source_nsxt_ns_service.go
@@ -48,11 +48,11 @@ func dataSourceNsxtNsServiceRead(d *schema.ResourceData, m interface{}) error {
 		// Get by id
 		objGet, resp, err := nsxClient.GroupingObjectsApi.ReadNSService(nsxClient.Context, objID)
 
-		if err != nil {
-			return fmt.Errorf("Error while reading ns service %s: %v", objID, err)
-		}
-		if resp.StatusCode == http.StatusNotFound {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
 			return fmt.Errorf("NS service %s was not found", objID)
+		}
+		if err != nil {
+			return fmt.Errorf("Error while reading NS service %s: %v", objID, err)
 		}
 		obj = objGet
 	} else if objName != "" {
@@ -74,7 +74,7 @@ func dataSourceNsxtNsServiceRead(d *schema.ResourceData, m interface{}) error {
 			}
 		}
 		if !found {
-			return fmt.Errorf("NS service '%s' was not found out of %d services", objName, len(objList.Results))
+			return fmt.Errorf("NS service with name '%s' was not found among %d services", objName, len(objList.Results))
 		}
 	} else {
 		return fmt.Errorf("Error obtaining NS service ID or name during read")

--- a/nsxt/data_source_nsxt_switching_profile.go
+++ b/nsxt/data_source_nsxt_switching_profile.go
@@ -53,11 +53,11 @@ func dataSourceNsxtSwitchingProfileRead(d *schema.ResourceData, m interface{}) e
 		// Get by id
 		objGet, resp, err := nsxClient.LogicalSwitchingApi.GetSwitchingProfile(nsxClient.Context, objID)
 
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return fmt.Errorf("switching profile %s was not found", objID)
+		}
 		if err != nil {
 			return fmt.Errorf("Error while reading switching profile %s: %v", objID, err)
-		}
-		if resp.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("switching profile %s was not found", objID)
 		}
 		obj = objGet
 	} else if objName != "" {
@@ -81,7 +81,7 @@ func dataSourceNsxtSwitchingProfileRead(d *schema.ResourceData, m interface{}) e
 			}
 		}
 		if !found {
-			return fmt.Errorf("Switching profile '%s' was not found", objName)
+			return fmt.Errorf("Switching profile with name '%s' was not found", objName)
 		}
 	} else {
 		return fmt.Errorf("Error obtaining switching profile ID or name during read")

--- a/nsxt/data_source_nsxt_transport_zone.go
+++ b/nsxt/data_source_nsxt_transport_zone.go
@@ -61,11 +61,11 @@ func dataSourceNsxtTransportZoneRead(d *schema.ResourceData, m interface{}) erro
 		// Get by id
 		objGet, resp, err := nsxClient.NetworkTransportApi.GetTransportZone(nsxClient.Context, objID)
 
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return fmt.Errorf("Transport zone %s was not found", objID)
+		}
 		if err != nil {
 			return fmt.Errorf("Error while reading transport zone %s: %v", objID, err)
-		}
-		if resp.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("Transport zone %s was not found", objID)
 		}
 		obj = objGet
 	} else if objName == "" {
@@ -99,7 +99,7 @@ func dataSourceNsxtTransportZoneRead(d *schema.ResourceData, m interface{}) erro
 			}
 			obj = prefixMatch[0]
 		} else {
-			return fmt.Errorf("Transport zone '%s' was not found", objName)
+			return fmt.Errorf("Transport zone with name '%s' was not found", objName)
 		}
 	}
 


### PR DESCRIPTION
404 error handling was based on false assumtion that API call does
not return error in case of 404 response. This was fixed earlier for
resources, this change completes the fix for data sources.