### PR TITLE
Support IPSet type in ns group membership criteria

### DIFF
--- a/nsxt/resource_nsxt_ip_set.go
+++ b/nsxt/resource_nsxt_ip_set.go
@@ -139,6 +139,7 @@ func resourceNsxtIPSetDelete(d *schema.ResourceData, m interface{}) error {
 	}
 
 	localVarOptionals := make(map[string]interface{})
+	localVarOptionals["force"] = true
 	resp, err := nsxClient.GroupingObjectsApi.DeleteIPSet(nsxClient.Context, id, localVarOptionals)
 	if err != nil {
 		return fmt.Errorf("Error during IpSet delete: %v", err)

--- a/nsxt/resource_nsxt_ns_group.go
+++ b/nsxt/resource_nsxt_ns_group.go
@@ -11,7 +11,7 @@ import (
 )
 
 var nsGroupTargetTypeValues = []string{"NSGroup", "IPSet", "LogicalPort", "LogicalSwitch", "MACSet"}
-var nsGroupMembershipCriteriaTargetTypeValues = []string{"LogicalPort", "LogicalSwitch", "VirtualMachine"}
+var nsGroupMembershipCriteriaTargetTypeValues = []string{"LogicalPort", "LogicalSwitch", "VirtualMachine", "IPSet"}
 var nsGroupTagOperationValues = []string{"EQUALS"}
 
 func resourceNsxtNsGroup() *schema.Resource {


### PR DESCRIPTION
In addition, force deletion of IPSet resource, in order to allow
deletion even if this set is active member in group via membership
criteria.