### PR TITLE
fix for "Error during IPPoolAllocationIPAddress delete: EOF"

### DIFF
--- a/nsxt/resource_nsxt_ip_pool_allocation_ip_address.go
+++ b/nsxt/resource_nsxt_ip_pool_allocation_ip_address.go
@@ -120,7 +120,8 @@ func resourceNsxtIPPoolAllocationIPAddressDelete(d *schema.ResourceData, m inter
 	if resp != nil && resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("Error during IPPoolAllocationIPAddress delete: status=%s", resp.Status)
 	}
-	if err != nil {
+	if resp == nil && err != nil {
+		// AllocateOrReleaseFromIpPool always returns an error EOF for action RELEASE, this is ignored if resp is set
 		return fmt.Errorf("Error during IPPoolAllocationIPAddress delete: %v", err)
 	}
 


### PR DESCRIPTION
A bug was introduced with the reordering of the error handling during the review of PR #190
