### PR TITLE
Add revision in switching profile update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ BUG FIXES:
 * `resource/nsxt_ip_set`: Allow force-deletion of IPSet even if its referenced in ns groups.
 * `resource/nsxt_logical_router_downlink_port`: Fix crash that happened during import with specific configuration ([#193](https://github.com/terraform-providers/terraform-provider-nsxt/pull/193))
 * `resource/nsxt_logical_router_link_port_on_tier1`: Fix crash that happened during import with specific configuration ([#193](https://github.com/terraform-providers/terraform-provider-nsxt/pull/193))
+* `resource/nsxt_*_switching_profile`: Fix update error that occured in some cases due to omitted revision ([#201](https://github.com/terraform-providers/terraform-provider-nsxt/pull/201))
 
 ## 1.1.1 (August 05, 2019)
 

--- a/nsxt/resource_nsxt_ip_discovery_switching_profile.go
+++ b/nsxt/resource_nsxt_ip_discovery_switching_profile.go
@@ -139,6 +139,7 @@ func resourceNsxtIPDiscoverySwitchingProfileUpdate(d *schema.ResourceData, m int
 	description := d.Get("description").(string)
 	displayName := d.Get("display_name").(string)
 	tags := getTagsFromSchema(d)
+	revision := int64(d.Get("revision").(int))
 	dhcpSnoopingEnabled := d.Get("dhcp_snooping_enabled").(bool)
 	arpSnoopingEnabled := d.Get("arp_snooping_enabled").(bool)
 	arpBindingsLimit := d.Get("arp_bindings_limit").(int)
@@ -152,6 +153,7 @@ func resourceNsxtIPDiscoverySwitchingProfileUpdate(d *schema.ResourceData, m int
 		ArpSnoopingEnabled:  arpSnoopingEnabled,
 		ArpBindingsLimit:    arpBindingsLimit,
 		VmToolsEnabled:      vmToolsEnabled,
+		Revision:            revision,
 	}
 
 	switchingProfile, resp, err := nsxClient.LogicalSwitchingApi.UpdateIpDiscoverySwitchingProfile(nsxClient.Context, id, switchingProfile)

--- a/nsxt/resource_nsxt_ip_discovery_switching_profile_test.go
+++ b/nsxt/resource_nsxt_ip_discovery_switching_profile_test.go
@@ -50,6 +50,13 @@ func TestAccResourceNsxtIpDiscoverySwitchingProfile_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
 				),
 			},
+			{
+				Config: testAccNSXIpDiscoverySwitchingProfileEmptyTemplate(updatedName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNSXIpDiscoverySwitchingProfileExists(updatedName, testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "0"),
+				),
+			},
 		},
 	})
 }
@@ -145,6 +152,14 @@ resource "nsxt_ip_discovery_switching_profile" "test" {
   }
 }
 `, name, vmToolsEnabled, arpSnoopingEnabled, dhcpSnoopingEnabled, arpBindingsLimit)
+}
+
+func testAccNSXIpDiscoverySwitchingProfileEmptyTemplate(name string) string {
+	return fmt.Sprintf(`
+resource "nsxt_ip_discovery_switching_profile" "test" {
+  display_name          = "%s"
+}
+`, name)
 }
 
 func testAccNSXIpDiscoverySwitchingProfileCreateTemplateTrivial(name string) string {

--- a/nsxt/resource_nsxt_mac_management_switching_profile.go
+++ b/nsxt/resource_nsxt_mac_management_switching_profile.go
@@ -182,6 +182,7 @@ func resourceNsxtMacManagementSwitchingProfileUpdate(d *schema.ResourceData, m i
 	description := d.Get("description").(string)
 	displayName := d.Get("display_name").(string)
 	tags := getTagsFromSchema(d)
+	revision := int64(d.Get("revision").(int))
 	macChangeAllowed := d.Get("mac_change_allowed").(bool)
 	macLearning := getMacLearningFromSchema(d)
 
@@ -191,6 +192,7 @@ func resourceNsxtMacManagementSwitchingProfileUpdate(d *schema.ResourceData, m i
 		Tags:             tags,
 		MacChangeAllowed: macChangeAllowed,
 		MacLearning:      macLearning,
+		Revision:         revision,
 	}
 
 	switchingProfile, resp, err := nsxClient.LogicalSwitchingApi.UpdateMacManagementSwitchingProfile(nsxClient.Context, id, switchingProfile)

--- a/nsxt/resource_nsxt_mac_management_switching_profile_test.go
+++ b/nsxt/resource_nsxt_mac_management_switching_profile_test.go
@@ -54,6 +54,14 @@ func TestAccResourceNsxtMacManagementSwitchingProfile_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
 				),
 			},
+			{
+				Config: testAccNSXMacManagementSwitchingProfileBasicTemplate(updatedName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNSXMacManagementSwitchingProfileExists(updatedName, testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "mac_learning.#", "0"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "0"),
+				),
+			},
 		},
 	})
 }
@@ -153,6 +161,14 @@ resource "nsxt_mac_management_switching_profile" "test" {
   }
 }
 `, name, macChange, macLearnEnabled, limit, limitPolicy, unicast)
+}
+
+func testAccNSXMacManagementSwitchingProfileBasicTemplate(name string) string {
+	return fmt.Sprintf(`
+resource "nsxt_mac_management_switching_profile" "test" {
+  display_name       = "%s"
+}
+`, name)
 }
 
 func testAccNSXMacManagementSwitchingProfileCreateTemplateTrivial(name string) string {

--- a/nsxt/resource_nsxt_qos_switching_profile.go
+++ b/nsxt/resource_nsxt_qos_switching_profile.go
@@ -264,6 +264,7 @@ func resourceNsxtQosSwitchingProfileUpdate(d *schema.ResourceData, m interface{}
 	description := d.Get("description").(string)
 	displayName := d.Get("display_name").(string)
 	tags := getTagsFromSchema(d)
+	revision := int64(d.Get("revision").(int))
 	classOfService := int32(d.Get("class_of_service").(int))
 	dscpTrusted := "UNTRUSTED"
 	if d.Get("dscp_trusted").(bool) {
@@ -288,6 +289,7 @@ func resourceNsxtQosSwitchingProfileUpdate(d *schema.ResourceData, m interface{}
 			Priority: dscpPriority,
 		},
 		ShaperConfiguration: shapers,
+		Revision:            revision,
 	}
 
 	qosSwitchingProfile, resp, err := nsxClient.LogicalSwitchingApi.UpdateQosSwitchingProfile(nsxClient.Context, id, qosSwitchingProfile)

--- a/nsxt/resource_nsxt_qos_switching_profile_test.go
+++ b/nsxt/resource_nsxt_qos_switching_profile_test.go
@@ -68,6 +68,15 @@ func TestAccResourceNsxtQosSwitchingProfile_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
 				),
 			},
+			{
+				Config: testAccNSXQosSwitchingProfileEmptyTemplate(updatedName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNSXQosSwitchingProfileExists(updatedName, testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "egress_rate_shaper.#", "0"),
+					resource.TestCheckResourceAttr(testResourceName, "ingress_broadcast_rate_shaper.#", "0"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "0"),
+				),
+			},
 		},
 	})
 }
@@ -174,6 +183,12 @@ resource "nsxt_qos_switching_profile" "test" {
   }
 }
 `, name, cos, direction, peak, peak)
+}
+
+func testAccNSXQosSwitchingProfileEmptyTemplate(name string) string {
+	return `
+resource "nsxt_qos_switching_profile" "test" {
+}`
 }
 
 func testAccNSXQosSwitchingProfileCreateTemplateTrivial(name string) string {

--- a/nsxt/resource_nsxt_spoofguard_switching_profile.go
+++ b/nsxt/resource_nsxt_spoofguard_switching_profile.go
@@ -117,6 +117,7 @@ func resourceNsxtSpoofGuardSwitchingProfileUpdate(d *schema.ResourceData, m inte
 	description := d.Get("description").(string)
 	displayName := d.Get("display_name").(string)
 	tags := getTagsFromSchema(d)
+	revision := int64(d.Get("revision").(int))
 	whiteListProviders := []string{}
 	if d.Get("address_binding_whitelist_enabled").(bool) {
 		whiteListProviders = append(whiteListProviders, "LPORT_BINDINGS")
@@ -127,6 +128,7 @@ func resourceNsxtSpoofGuardSwitchingProfileUpdate(d *schema.ResourceData, m inte
 		DisplayName:        displayName,
 		Tags:               tags,
 		WhiteListProviders: whiteListProviders,
+		Revision:           revision,
 	}
 
 	sgSwitchingProfile, resp, err := nsxClient.LogicalSwitchingApi.UpdateSpoofGuardSwitchingProfile(nsxClient.Context, id, sgSwitchingProfile)

--- a/nsxt/resource_nsxt_spoofguard_switching_profile_test.go
+++ b/nsxt/resource_nsxt_spoofguard_switching_profile_test.go
@@ -44,6 +44,13 @@ func TestAccResourceNsxtSpoofGuardSwitchingProfile_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
 				),
 			},
+			{
+				Config: testAccNSXSpoofGuardSwitchingProfileEmptyTemplate(updatedName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNSXSpoofGuardSwitchingProfileExists(updatedName, testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "0"),
+				),
+			},
 		},
 	})
 }
@@ -136,4 +143,12 @@ resource "nsxt_spoofguard_switching_profile" "test" {
   }
 }
 `, name, enableWhitelist)
+}
+
+func testAccNSXSpoofGuardSwitchingProfileEmptyTemplate(name string) string {
+	return fmt.Sprintf(`
+resource "nsxt_spoofguard_switching_profile" "test" {
+  display_name                      = "%s"
+}
+`, name)
 }

--- a/nsxt/resource_nsxt_switch_security_switching_profile.go
+++ b/nsxt/resource_nsxt_switch_security_switching_profile.go
@@ -252,6 +252,7 @@ func resourceNsxtSwitchSecuritySwitchingProfileUpdate(d *schema.ResourceData, m 
 	description := d.Get("description").(string)
 	displayName := d.Get("display_name").(string)
 	tags := getTagsFromSchema(d)
+	revision := int64(d.Get("revision").(int))
 	blockNonIP := d.Get("block_non_ip").(bool)
 	blockClientDHCP := d.Get("block_client_dhcp").(bool)
 	blockServerDHCP := d.Get("block_server_dhcp").(bool)
@@ -273,6 +274,7 @@ func resourceNsxtSwitchSecuritySwitchingProfileUpdate(d *schema.ResourceData, m 
 			WhiteList: bpduFilterWhitelist,
 		},
 		RateLimits: rateLimits,
+		Revision:   revision,
 	}
 
 	switchSecurityProfile, resp, err := nsxClient.LogicalSwitchingApi.UpdateSwitchSecuritySwitchingProfile(nsxClient.Context, id, switchSecurityProfile)

--- a/nsxt/resource_nsxt_switch_security_switching_profile_test.go
+++ b/nsxt/resource_nsxt_switch_security_switching_profile_test.go
@@ -64,6 +64,15 @@ func TestAccResourceNsxtSwitchSecuritySwitchingProfile_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
 				),
 			},
+			{
+				Config: testAccNSXSwitchSecuritySwitchingProfileEmptyTemplate(updatedName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNSXSwitchSecuritySwitchingProfileExists(updatedName, testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "bpdu_filter_whitelist.#", "0"),
+					resource.TestCheckResourceAttr(testResourceName, "rate_limits.#", "0"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "0"),
+				),
+			},
 		},
 	})
 }
@@ -168,6 +177,13 @@ resource "nsxt_switch_security_switching_profile" "test" {
   }
 }
 `, name, limit, limit, limit, limit)
+}
+func testAccNSXSwitchSecuritySwitchingProfileEmptyTemplate(name string) string {
+	return fmt.Sprintf(`
+resource "nsxt_switch_security_switching_profile" "test" {
+  display_name          = "%s"
+}
+`, name)
 }
 
 func testAccNSXSwitchSecuritySwitchingProfileCreateTemplateTrivial(name string) string {


### PR DESCRIPTION
Revision was not conveyed to server in switching profiles update.
This caused the update to be rejected in some cases. This change
adds revision and tests for scenario that was failing.