### PR TITLE
Detach logical switch before deleting it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ BUG FIXES:
 * `resource/nsxt_logical_router_downlink_port`: Fix crash that happened during import with specific configuration ([#193](https://github.com/terraform-providers/terraform-provider-nsxt/pull/193))
 * `resource/nsxt_logical_router_link_port_on_tier1`: Fix crash that happened during import with specific configuration ([#193](https://github.com/terraform-providers/terraform-provider-nsxt/pull/193))
 * `resource/nsxt_*_switching_profile`: Fix update error that occured in some cases due to omitted revision ([#201](https://github.com/terraform-providers/terraform-provider-nsxt/pull/201))
+* `resource/nsxt_logical_switch`: On delete operation, detach logical switch in order to avoid possible dependency errors ([#202](https://github.com/terraform-providers/terraform-provider-nsxt/pull/202))
 
 ## 1.1.1 (August 05, 2019)
 

--- a/nsxt/resource_nsxt_logical_switch.go
+++ b/nsxt/resource_nsxt_logical_switch.go
@@ -289,6 +289,7 @@ func resourceNsxtLogicalSwitchDelete(d *schema.ResourceData, m interface{}) erro
 
 	localVarOptionals := make(map[string]interface{})
 	localVarOptionals["cascade"] = true
+	localVarOptionals["detach"] = true
 	resp, err := nsxClient.LogicalSwitchingApi.DeleteLogicalSwitch(nsxClient.Context, id, localVarOptionals)
 	if err != nil {
 		return fmt.Errorf("Error during LogicalSwitch delete: %v", err)


### PR DESCRIPTION
This should allow deleting logical switch even if it still has
dependencies.
In future, we plan to add a provider flag that would control all "detach" and "force-delete" behaviors.