### PR TITLE
skip TestAccDataSourceNsxtPolicyVM_basic without env var

### DIFF
--- a/nsxt/data_source_nsxt_policy_vm_test.go
+++ b/nsxt/data_source_nsxt_policy_vm_test.go
@@ -13,7 +13,11 @@ func TestAccDataSourceNsxtPolicyVM_basic(t *testing.T) {
 	testResourceName := "data.nsxt_policy_vm.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccEnvDefined(t, "NSXT_TEST_VM_ID")
+			testAccEnvDefined(t, "NSXT_TEST_VM_NAME")
+		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{


### PR DESCRIPTION
Add PreCheck conditions for TestAccDataSourceNsxtPolicyVM_basic to skip
the test if the NSXT_TEST_VM_ID and NSXT_TEST_VM_NAME env vars are not
set.