### PR TITLE
Expose enforcement point argument on provider

### DIFF
--- a/nsxt/data_source_nsxt_policy_edge_cluster.go
+++ b/nsxt/data_source_nsxt_policy_edge_cluster.go
@@ -34,7 +34,7 @@ func dataSourceNsxtPolicyEdgeClusterRead(d *schema.ResourceData, m interface{}) 
 	var obj model.PolicyEdgeCluster
 	if objID != "" {
 		// Get by id
-		objGet, err := client.Get(defaultSite, defaultEnforcementPoint, objID)
+		objGet, err := client.Get(defaultSite, policyEnforcementPoint, objID)
 
 		if err != nil {
 			return fmt.Errorf("Error while reading edge cluster %s: %v", objID, err)
@@ -45,7 +45,7 @@ func dataSourceNsxtPolicyEdgeClusterRead(d *schema.ResourceData, m interface{}) 
 	} else {
 		// Get by full name/prefix
 		includeMarkForDeleteObjectsParam := false
-		objList, err := client.List(defaultSite, defaultEnforcementPoint, nil, &includeMarkForDeleteObjectsParam, nil, nil, nil, nil)
+		objList, err := client.List(defaultSite, policyEnforcementPoint, nil, &includeMarkForDeleteObjectsParam, nil, nil, nil, nil)
 		if err != nil {
 			return fmt.Errorf("Error while reading edge clusters: %v", err)
 		}

--- a/nsxt/data_source_nsxt_policy_edge_node.go
+++ b/nsxt/data_source_nsxt_policy_edge_node.go
@@ -47,7 +47,7 @@ func dataSourceNsxtPolicyEdgeNodeRead(d *schema.ResourceData, m interface{}) err
 	var obj model.PolicyEdgeNode
 	if objID != "" {
 		// Get by id
-		objGet, err := client.Get(defaultSite, defaultEnforcementPoint, edgeClusterID, objID)
+		objGet, err := client.Get(defaultSite, policyEnforcementPoint, edgeClusterID, objID)
 
 		if err != nil {
 			return fmt.Errorf("Error while reading edge node %s: %v", objID, err)
@@ -56,7 +56,7 @@ func dataSourceNsxtPolicyEdgeNodeRead(d *schema.ResourceData, m interface{}) err
 	} else {
 		// Get by full name/prefix
 		includeMarkForDeleteObjectsParam := false
-		objList, err := client.List(defaultSite, defaultEnforcementPoint, edgeClusterID, nil, &includeMarkForDeleteObjectsParam, nil, nil, nil, nil)
+		objList, err := client.List(defaultSite, policyEnforcementPoint, edgeClusterID, nil, &includeMarkForDeleteObjectsParam, nil, nil, nil, nil)
 		if err != nil {
 			return fmt.Errorf("Error while reading edge nodes: %v", err)
 		}

--- a/nsxt/data_source_nsxt_policy_transport_zone_test.go
+++ b/nsxt/data_source_nsxt_policy_transport_zone_test.go
@@ -27,6 +27,16 @@ func TestAccDataSourceNsxtPolicyTransportZone_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "transport_type", "VLAN_BACKED"),
 				),
 			},
+			{
+				Config: testAccNSXPolicyTransportZoneWithTransportTypeTemplate(transportZoneName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(testResourceName, "display_name", transportZoneName),
+					resource.TestCheckResourceAttrSet(testResourceName, "id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "is_default"),
+					resource.TestCheckResourceAttr(testResourceName, "transport_type", "VLAN_BACKED"),
+				),
+			},
 		},
 	})
 }
@@ -35,5 +45,13 @@ func testAccNSXPolicyTransportZoneReadTemplate(transportZoneName string) string 
 	return fmt.Sprintf(`
 data "nsxt_policy_transport_zone" "test" {
   display_name = "%s"
+}`, transportZoneName)
+}
+
+func testAccNSXPolicyTransportZoneWithTransportTypeTemplate(transportZoneName string) string {
+	return fmt.Sprintf(`
+data "nsxt_policy_transport_zone" "test" {
+  display_name   = "%s"
+  transport_type = "VLAN_BACKED"
 }`, transportZoneName)
 }

--- a/nsxt/policy_common.go
+++ b/nsxt/policy_common.go
@@ -9,7 +9,6 @@ import (
 
 var defaultDomain = "default"
 var defaultSite = "default"
-var defaultEnforcementPoint = "default"
 var securityPolicyCategoryValues = []string{"Ethernet", "Emergency", "Infrastructure", "Environment", "Application"}
 var securityPolicyDirectionValues = []string{model.Rule_DIRECTION_IN, model.Rule_DIRECTION_OUT, model.Rule_DIRECTION_IN_OUT}
 var securityPolicyIPProtocolValues = []string{model.Rule_IP_PROTOCOL_IPV4, model.Rule_IP_PROTOCOL_IPV6, model.Rule_IP_PROTOCOL_IPV4_IPV6}

--- a/nsxt/provider.go
+++ b/nsxt/provider.go
@@ -21,6 +21,7 @@ import (
 
 var defaultRetryOnStatusCodes = []int{429, 503}
 var toleratePartialSuccess = false
+var policyEnforcementPoint = "default"
 
 type nsxtClients struct {
 	// NSX Manager client - based on go-vmware-nsxt SDK
@@ -129,6 +130,12 @@ func Provider() terraform.ResourceProvider {
 				Optional:    true,
 				Description: "Long-living API token for VMC authorization",
 				DefaultFunc: schema.EnvDefaultFunc("NSXT_VMC_TOKEN", nil),
+			},
+			"enforcement_point": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Enforcement Point for NSXT Policy",
+				DefaultFunc: schema.EnvDefaultFunc("NSXT_POLICY_ENFORCEMENT_POINT", "default"),
 			},
 		},
 
@@ -442,6 +449,7 @@ func configurePolicyConnectorData(d *schema.ResourceData, clients *nsxtClients) 
 	clientAuthCertFile := d.Get("client_auth_cert_file").(string)
 	clientAuthKeyFile := d.Get("client_auth_key_file").(string)
 	caFile := d.Get("ca_file").(string)
+	policyEnforcementPoint = d.Get("enforcement_point").(string)
 
 	if hostIP == "" {
 		return fmt.Errorf("host must be provided")

--- a/nsxt/resource_nsxt_policy_vm_tags.go
+++ b/nsxt/resource_nsxt_policy_vm_tags.go
@@ -114,8 +114,7 @@ func updateNsxtPolicyVMTags(connector *client.RestConnector, externalID string, 
 		Tags:             tags,
 		VirtualMachineId: externalID,
 	}
-	// TODO: make enforcement point configurable
-	return client.Updatetags(defaultEnforcementPoint, tagUpdate)
+	return client.Updatetags(policyEnforcementPoint, tagUpdate)
 }
 
 func resourceNsxtPolicyVMTagsRead(d *schema.ResourceData, m interface{}) error {

--- a/website/docs/d/policy_transport_zone.html.markdown
+++ b/website/docs/d/policy_transport_zone.html.markdown
@@ -17,10 +17,19 @@ data "nsxt_policy_transport_zone" "overlay_transport_zone" {
 }
 ```
 
+```hcl
+data "nsxt_policy_transport_zone" "vlan_transport_zone" {
+  transport_type = "VLAN_BACKED"
+  is_default     = true
+}
+```
+
 ## Argument Reference
 
 * `id` - (Optional) The ID of Transport Zone to retrieve.
 * `display_name` - (Optional) The Display Name prefix of the Transport Zone to retrieve.
+* `transport_type` - (Optional) Transport type of requested Transport Zone, one of `OVERLAY_STANDARD`, `OVERLAY_ENS`, `VLAN_BACKED` and `UNKNOWN`.
+* `is_default` - (Optional) May be set together with `transport_type` in order to retrieve default Transport Zone for for this transport type.
 
 ## Attributes Reference
 
@@ -28,5 +37,5 @@ In addition to arguments listed above, the following attributes are exported:
 
 * `description` - The description of the Transport Zone.
 * `is_default` - A boolean flag indicating if this Transport Zone is the default.
-* `transport_type` - The transport type of this transport zone (`OVERLAY` or `VLAN`).
+* `transport_type` - The transport type of this transport zone.
 * `path` - The NSX path of the policy resource.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -118,6 +118,7 @@ provider "nsxt" {
   host                 = "x-54-200-54-5.rp.vmwarevmc.com/vmc/reverse-proxy/api/orgs/b003c3a5-3f68-4a8c-a74f-f79a0625da17/sddcs/d2f43050-f4e2-4989-ab52-2eb0b89d8487/sks-nsxt-manager"
   vmc_token            = "5aVZEj6dJN1bQ6ZheakMyV0Qbj7P65sa2pYuhgx7Mp5glvgCkFKHcGxy3KmslllT"
   allow_unverified_ssl = true
+  enforcement_point    = "vmc-enforcementpoint"
 }
 
 ```
@@ -173,6 +174,9 @@ The following arguments are used to configure the VMware NSX-T Provider:
 * `vmc_auth_host` - (Optional) URL for VMC authorization service that is used
   to obtain short-lived token for NSX manager access. Defaults to VMC
   console authorization URL.
+* `enforcement_point` - (Optional) Enforcement point, mostly relevant for policy
+  data sources. For VMC environment, this should be set to `vmc-enforcementpoint`.
+  For on-prem deployments, this setting should not be specified.
 
 ## NSX Logical Networking
 


### PR DESCRIPTION
Some policy data sources make use of APIs based on enforcement points.
In VMC environment, enforcement point ID has non-default setting.
This change allows user to configure enforcement point on provider
level.
In addition, this change allows to pull default TZ per transport type
via nsxt_policy_transport_zone data source.