### PR TITLE
Update doc for dhcp_ranges

### DIFF
--- a/website/docs/r/policy_segment.html.markdown
+++ b/website/docs/r/policy_segment.html.markdown
@@ -19,7 +19,7 @@ resource "nsxt_policy_segment" "segment1" {
 
     subnet {
       cidr        = "12.12.2.1/24"
-      dhcp_ranges = "12.12.2.100-12.12.2.160"
+      dhcp_ranges = ["12.12.2.100-12.12.2.160"]
 
       dhcp_v4_config {
         lease_time = 36000
@@ -58,7 +58,7 @@ The following arguments are supported:
 * `dhcp_config_path` - (Optional) Policy path to DHCP server or relay configuration to use for subnets configured on this segment. This attribute is supported with NSX 3.0.0 onwards.
 * `subnet` - (Required) Subnet configuration block.
   * `cidr` - (Required) Gateway IP address CIDR.
-  * `dhcp_ranges` - (Optional) DHCP address ranges for dynamic IP allocation.
+  * `dhcp_ranges` - (Optional) List of DHCP address ranges for dynamic IP allocation.
   * `dhcp_v4_config` - (Optional) DHCPv4 config for IPv4 subnet. This clause is supported with NSX 3.0.0 onwards.
     * `dns_servers` - (Optional) List of IP addresses of DNS servers for the subnet.
     * `lease_time`  - (Optional) DHCP lease time in seconds.

--- a/website/docs/r/policy_vlan_segment.html.markdown
+++ b/website/docs/r/policy_vlan_segment.html.markdown
@@ -21,7 +21,7 @@ resource "nsxt_policy_vlan_segment" "vlansegment1" {
 
   subnet {
     cidr        = "12.12.2.1/24"
-    dhcp_ranges = "12.12.2.100-12.12.2.160"
+    dhcp_ranges = ["12.12.2.100-12.12.2.160"]
 
     dhcp_v4_config {
       lease_time = 36000
@@ -59,7 +59,7 @@ The following arguments are supported:
 * `dhcp_config_path` - (Optional) Policy path to DHCP server or relay configuration to use for subnets configured on this segment. This attribute is supported with NSX 3.0.0 onwards.
 * `subnet` - (Required) Subnet configuration block.
   * `cidr` - (Required) Gateway IP address CIDR.
-  * `dhcp_ranges` - (Optional) DHCP address ranges for dynamic IP allocation.
+  * `dhcp_ranges` - (Optional) List of DHCP address ranges for dynamic IP allocation.
   * `dhcp_v4_config` - (Optional) DHCPv4 config for IPv4 subnet. This attribute is supported with NSX 3.0.0 onwards.
     * `dns_servers` - (Optional) List of IP addresses of DNS servers for the subnet.
     * `lease_time`  - (Optional) DHCP lease time in seconds.


### PR DESCRIPTION
According to [this](https://github.com/terraform-providers/terraform-provider-nsxt/blob/master/nsxt/segment_common.go#L109), `dhcp_ranges` should be a list of strings.