### PR TITLE
Policy block subnet - wait for delete realization

### DIFF
--- a/nsxt/resource_nsxt_policy_ip_pool_block_subnet_test.go
+++ b/nsxt/resource_nsxt_policy_ip_pool_block_subnet_test.go
@@ -203,8 +203,8 @@ resource "nsxt_policy_ip_pool" "pool1" {
 resource "nsxt_policy_ip_pool_block_subnet" "test" {
   display_name = "%s"
   size         = 4
-  pool_path    = "${nsxt_policy_ip_pool.pool1.path}"
-  block_path   = "${nsxt_policy_ip_block.block1.path}"
+  pool_path    = nsxt_policy_ip_pool.pool1.path
+  block_path   = nsxt_policy_ip_block.block1.path
 }`, nsxtPolicyBlockSubnetPoolID, nsxtPolicyBlockSubnetPoolID, name)
 }
 
@@ -220,8 +220,8 @@ resource "nsxt_policy_ip_pool_block_subnet" "test" {
   description         = "Acceptance Test"
   size                = 4
   auto_assign_gateway = false
-  pool_path           = "${nsxt_policy_ip_pool.pool1.path}"
-  block_path          = "${nsxt_policy_ip_block.block1.path}"
+  pool_path           = nsxt_policy_ip_pool.pool1.path
+  block_path          = nsxt_policy_ip_block.block1.path
   tag {
     scope = "scope2"
     tag   = "tag2"
@@ -241,8 +241,8 @@ resource "nsxt_policy_ip_pool_block_subnet" "test" {
   description         = "Acceptance Test"
   size                = 4
   auto_assign_gateway = true
-  pool_path           = "${nsxt_policy_ip_pool.pool1.path}"
-  block_path          = "${nsxt_policy_ip_block.block1.path}"
+  pool_path           = nsxt_policy_ip_pool.pool1.path
+  block_path          = nsxt_policy_ip_block.block1.path
   tag {
     scope = "scope1"
     tag   = "tag1"


### PR DESCRIPTION
Due to asyncronous IPAM implementation in NSXT Policy, deleting
block subnet doesn't guarantee subnet is actually freed. This can
cause issues like subsequent block deletion. To verify consistency,
this change implements waiting for delete realization.
Note: This workaround will not be needed for future platform
versions, where IPAM will be fully managed by NSXT Policy.