### PR TITLE
Apply logical_port_tags to all VM ports

### DIFF
--- a/website/docs/r/vm_tags.html.markdown
+++ b/website/docs/r/vm_tags.html.markdown
@@ -33,7 +33,7 @@ The following arguments are supported:
 
 * `instance_id` - (Required) BIOS Id of the Virtual Machine.
 * `tag` - (Optional) A list of scope + tag pairs to associate with this VM.
-* `logical_port_tag` - (Optional) A list of scope + tag pairs to associate with logical port that is automatically created for this VM.
+* `logical_port_tag` - (Optional) A list of scope + tag pairs to associate with all logical ports that are automatically created for this VM.
 
 ## Importing
 


### PR DESCRIPTION
When VM is attached to multiple NSX switches, nsxt_vm_tags resource
needs to update logical port tags on all relevant logical ports.
We assume tags are fully managed by terraform and thus are the same
for all ports.