### PR TITLE
Improve error report when error conversion fails

### DIFF
--- a/nsxt/policy_errors.go
+++ b/nsxt/policy_errors.go
@@ -6,6 +6,7 @@ package nsxt
 import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std"
 	"github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
@@ -13,9 +14,50 @@ import (
 	"log"
 )
 
-func logVapiErrorData(message string, apiErrorDataValue *data.StructValue) error {
+func printAPIError(apiError model.ApiError) string {
+	if apiError.ErrorMessage != nil && apiError.ErrorCode != nil {
+		return fmt.Sprintf("%s (code %v)", *apiError.ErrorMessage, *apiError.ErrorCode)
+	}
+
+	if apiError.ErrorMessage != nil {
+		return *apiError.ErrorMessage
+	}
+
+	if apiError.ErrorCode != nil {
+		return fmt.Sprintf("(code %v)", *apiError.ErrorCode)
+	}
+
+	return ""
+}
+
+// TODO: Remove duplicate code when sdk implements composition of API inheritance model
+func printRelatedAPIError(apiError model.RelatedApiError) string {
+	if apiError.ErrorMessage != nil && apiError.ErrorCode != nil {
+		return fmt.Sprintf("%s (code %v)", *apiError.ErrorMessage, *apiError.ErrorCode)
+	}
+
+	if apiError.ErrorMessage != nil {
+		return *apiError.ErrorMessage
+	}
+
+	if apiError.ErrorCode != nil {
+		return fmt.Sprintf("(code %v)", *apiError.ErrorCode)
+	}
+
+	return ""
+}
+
+func logVapiErrorData(message string, vapiMessages []std.LocalizableMessage, vapiType *errors.ErrorType, apiErrorDataValue *data.StructValue) error {
+
 	if apiErrorDataValue == nil {
-		return fmt.Errorf("[ERROR]: %s (no additional details provided)", message)
+		if len(vapiMessages) > 0 {
+			return fmt.Errorf("%s (%s)", message, vapiMessages[0].DefaultMessage)
+		}
+		if vapiType != nil {
+			return fmt.Errorf("%s (%s)", message, *vapiType)
+		}
+
+		return fmt.Errorf("%s (no additional details provided)", message)
 	}
 
 	var typeConverter = bindings.NewTypeConverter()
@@ -23,16 +65,29 @@ func logVapiErrorData(message string, apiErrorDataValue *data.StructValue) error
 	data, err := typeConverter.ConvertToGolang(apiErrorDataValue, model.ApiErrorBindingType())
 
 	if err != nil {
-		log.Printf("[ERROR] Failed to extract error details: %s", err)
-		return fmt.Errorf("%s (failed to extract additional details due to %s)", message, err)
+		log.Printf("[ERROR]: Failed to extract error details: %s", err)
+		// In NSX 2.5 error is sent in wrong format, hence the sdk fails to decode it
+		// In order to ease user experience, print default message in case its present
+		// This bug is fixed in NSX 3.0 onwards
+		if len(vapiMessages) > 0 {
+			return fmt.Errorf("%s (%s)", message, vapiMessages[0].DefaultMessage)
+		}
+		// error type is the only piece of info we have here
+		if vapiType != nil {
+			return fmt.Errorf("%s (%s)", message, *vapiType)
+		}
+
+		return fmt.Errorf("%s (no additional details provided)", message)
 	}
+
 	apiError := data.(model.ApiError)
-	details := fmt.Sprintf(" %s: %s (code %v)", message, *apiError.ErrorMessage, *apiError.ErrorCode)
+
+	details := fmt.Sprintf(" %s: %s", message, printAPIError(apiError))
 
 	if len(apiError.RelatedErrors) > 0 {
 		details += "\nRelated errors:\n"
 		for _, relatedErr := range apiError.RelatedErrors {
-			details += fmt.Sprintf("%s (code %v)", *relatedErr.ErrorMessage, relatedErr.ErrorCode)
+			details += fmt.Sprintf("%s ", printRelatedAPIError(relatedErr))
 		}
 	}
 	log.Printf("[ERROR]: %s", details)
@@ -42,28 +97,22 @@ func logVapiErrorData(message string, apiErrorDataValue *data.StructValue) error
 func logAPIError(message string, err error) error {
 	if vapiError, ok := err.(errors.InvalidRequest); ok {
 		// Connection errors end up here
-		if vapiError.Data == nil {
-			if len(vapiError.Messages) > 0 {
-				return fmt.Errorf("[ERROR]: %s (%s)", message, vapiError.Messages[0].DefaultMessage)
-			}
-			return fmt.Errorf("[ERROR]: %s (no additional details provided)", message)
-		}
-		return logVapiErrorData(message, vapiError.Data)
+		return logVapiErrorData(message, vapiError.Messages, vapiError.ErrorType, vapiError.Data)
 	}
 	if vapiError, ok := err.(errors.NotFound); ok {
-		return logVapiErrorData(message, vapiError.Data)
+		return logVapiErrorData(message, vapiError.Messages, vapiError.ErrorType, vapiError.Data)
 	}
 	if vapiError, ok := err.(errors.Unauthorized); ok {
-		return logVapiErrorData(message, vapiError.Data)
+		return logVapiErrorData(message, vapiError.Messages, vapiError.ErrorType, vapiError.Data)
 	}
 	if vapiError, ok := err.(errors.Unauthenticated); ok {
-		return logVapiErrorData(message, vapiError.Data)
+		return logVapiErrorData(message, vapiError.Messages, vapiError.ErrorType, vapiError.Data)
 	}
 	if vapiError, ok := err.(errors.InternalServerError); ok {
-		return logVapiErrorData(message, vapiError.Data)
+		return logVapiErrorData(message, vapiError.Messages, vapiError.ErrorType, vapiError.Data)
 	}
 	if vapiError, ok := err.(errors.ServiceUnavailable); ok {
-		return logVapiErrorData(message, vapiError.Data)
+		return logVapiErrorData(message, vapiError.Messages, vapiError.ErrorType, vapiError.Data)
 	}
 
 	return err


### PR DESCRIPTION
With NSX 2.5, some API errors are badly formatted by nsx (error
format does not meet API spec). In this case, sdk conversion fails.
Message details are lost, but some information (such as error type)
should be presented for the user.