### PR TITLE
Re-apply detach fix for logical switch resource

### DIFF
--- a/nsxt/resource_nsxt_logical_switch.go
+++ b/nsxt/resource_nsxt_logical_switch.go
@@ -306,6 +306,7 @@ func resourceNsxtLogicalSwitchDelete(d *schema.ResourceData, m interface{}) erro
 
 	localVarOptionals := make(map[string]interface{})
 	localVarOptionals["cascade"] = true
+	localVarOptionals["detach"] = true
 	resp, err := nsxClient.LogicalSwitchingApi.DeleteLogicalSwitch(nsxClient.Context, id, localVarOptionals)
 	if err != nil {
 		return fmt.Errorf("Error during LogicalSwitch delete: %v", err)


### PR DESCRIPTION
This change reapplies patch d6d6675a18410b3a0f51b1f91c23380c82ec38c1
that got lost in merge.