### PR TITLE
Fix tag removal in vm tags resource

### DIFF
--- a/nsxt/utils.go
+++ b/nsxt/utils.go
@@ -121,7 +121,7 @@ func getTagsSchemaForceNew() *schema.Schema {
 
 func getCustomizedTagsFromSchema(d *schema.ResourceData, schemaName string) []common.Tag {
 	tags := d.Get(schemaName).(*schema.Set).List()
-	var tagList []common.Tag
+	tagList := make([]common.Tag, 0)
 	for _, tag := range tags {
 		data := tag.(map[string]interface{})
 		elem := common.Tag{


### PR DESCRIPTION
In order to update tags to empty list, sdk expects empty slice,
rather then nil slice, to be passed to update tags call. This way
tags will not be omitted from API call.
This doesn't affect general resources, since update function
uses PUT Api which will wipe out tags if not passed.