### PR TITLE
Fix creation of Tier0 with bgp config

### DIFF
--- a/nsxt/resource_nsxt_policy_tier0_gateway.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway.go
@@ -156,7 +156,7 @@ func getPolicyBGPConfigSchema() *schema.Schema {
 					Type:        schema.TypeBool,
 					Description: "Flag to enable BGP multipath relax option",
 					Optional:    true,
-					Default:     true,
+					Default:     false,
 				},
 				"route_aggregation": {
 					Type:        schema.TypeList,
@@ -721,10 +721,9 @@ func resourceNsxtPolicyTier0GatewayCreate(d *schema.ResourceData, m interface{})
 		return handleCreateError("Tier0", id, err)
 	}
 
-	boolTrue := true
+	boolFalse := false
 	log.Printf("[INFO] H-API Creating Tier0 with ID %s", id)
-	// use enforce_revision_check to ensure multipath_relax is created with default of true as per bug 2479086
-	err = infraClient.Patch(infraModel, &boolTrue)
+	err = infraClient.Patch(infraModel, &boolFalse)
 	if err != nil {
 		return handleCreateError("Tier0", id, err)
 	}

--- a/nsxt/resource_nsxt_policy_tier0_gateway_test.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway_test.go
@@ -198,7 +198,7 @@ func TestAccResourceNsxtPolicyTier0Gateway_withEdgeCluster(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "bgp_config.0.enabled", "true"),
 					resource.TestCheckResourceAttr(testResourceName, "bgp_config.0.inter_sr_ibgp", "true"),
 					resource.TestCheckResourceAttr(testResourceName, "bgp_config.0.local_as_num", "65000"),
-					resource.TestCheckResourceAttr(testResourceName, "bgp_config.0.multipath_relax", "true"),
+					resource.TestCheckResourceAttr(testResourceName, "bgp_config.0.multipath_relax", "false"),
 					resource.TestCheckResourceAttr(testResourceName, "bgp_config.0.route_aggregation.#", "0"),
 					resource.TestCheckResourceAttr(testResourceName, "bgp_config.0.graceful_restart_mode", "HELPER_ONLY"),
 					resource.TestCheckResourceAttr(testResourceName, "bgp_config.0.graceful_restart_timer", "180"),
@@ -253,6 +253,46 @@ func TestAccResourceNsxtPolicyTier0Gateway_withEdgeCluster(t *testing.T) {
 				),
 			},
 			*/
+		},
+	})
+}
+
+func TestAccResourceNsxtPolicyTier0Gateway_createWithBGP(t *testing.T) {
+	name := fmt.Sprintf("test-nsx-policy-tier0-bgp")
+	updateName := fmt.Sprintf("%s-update", name)
+	testResourceName := "nsxt_policy_tier0_gateway.test"
+	edgeClusterName := getEdgeClusterName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyTier0CheckDestroy(state, name)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyTier0UpdateWithEcTemplate(updateName, edgeClusterName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyTier0Exists(testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", updateName),
+					resource.TestCheckResourceAttr(testResourceName, "description", "Acceptance Test"),
+					resource.TestCheckResourceAttrSet(testResourceName, "edge_cluster_path"),
+					resource.TestCheckResourceAttr(realizationResourceName, "state", "REALIZED"),
+					resource.TestCheckResourceAttr(testResourceName, "bgp_config.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "bgp_config.0.tag.#", "0"),
+					resource.TestCheckResourceAttrSet(testResourceName, "bgp_config.0.revision"),
+					resource.TestCheckResourceAttrSet(testResourceName, "bgp_config.0.path"),
+					resource.TestCheckResourceAttr(testResourceName, "bgp_config.0.ecmp", "true"),
+					resource.TestCheckResourceAttr(testResourceName, "bgp_config.0.enabled", "true"),
+					resource.TestCheckResourceAttr(testResourceName, "bgp_config.0.inter_sr_ibgp", "true"),
+					resource.TestCheckResourceAttr(testResourceName, "bgp_config.0.local_as_num", "60000"),
+					resource.TestCheckResourceAttr(testResourceName, "bgp_config.0.multipath_relax", "true"),
+					resource.TestCheckResourceAttr(testResourceName, "bgp_config.0.route_aggregation.#", "2"),
+					resource.TestCheckResourceAttr(testResourceName, "bgp_config.0.graceful_restart_mode", "HELPER_ONLY"),
+					resource.TestCheckResourceAttr(testResourceName, "bgp_config.0.graceful_restart_timer", "180"),
+					resource.TestCheckResourceAttr(testResourceName, "bgp_config.0.graceful_restart_stale_route_timer", "600"),
+				),
+			},
 		},
 	})
 }

--- a/website/docs/r/policy_group.html.markdown
+++ b/website/docs/r/policy_group.html.markdown
@@ -59,7 +59,7 @@ The following arguments are supported:
     * `key` (Required for a `condition`) Specifies the attribute to query. Must be one of: `Tag`, `ComputerName`, `OSName` or `Name`. For a `member_type` other than `VirtualMachine`, only the `Tag` key is supported.
     * `member_type` (Required for a `condition`) Specifies the type of resource to query. Must be one of: `IPSet`, `LogicalPort`, `LogicalSwitch`, `Segment`, `SegmentPort` or `VirtualMachine`.
     * `operator` (Required for a `condition`) Specifies the query operator to use. Must be one of: `CONTAINS`, `ENDSWITH`, `EQUALS`, `NOTEQUALS` or `STARTSWITH`.
-    * `value` (Required for a `condition`) User specified string value to use in the query.
+    * `value` (Required for a `condition`) User specified string value to use in the query. For `Tag` criteria, use 'scope|value' notation if you wish to specify scope in criteria.
 * `conjunction` (Required for multiple `criteria`) When specifying multiple `criteria`, a conjunction is used to specify if the criteria should selected using `AND` or `OR`.
   * `operator` (Required for `conjunction`) The operator to use. Must be one of `AND` or `OR`. If `AND` is used, then the `criteria` block before/after must be of the same type and if using `condition` then also must use the same `member_type`.
 


### PR DESCRIPTION
This was failing due to revision check enforcement. This patch
removes revision check enforcement and changes default for
multipath_relax according to platform default.
In addition, it clarifies group memebership tag usage to match by
tag scope.