### PR TITLE
Allow loopback T0 interface and fix VRF acc tests

### DIFF
--- a/nsxt/data_source_nsxt_policy_realization_info_test.go
+++ b/nsxt/data_source_nsxt_policy_realization_info_test.go
@@ -144,6 +144,7 @@ resource "nsxt_policy_ip_address_allocation" "test" {
   display_name  = "tfipallocationerror"
   pool_path     = nsxt_policy_ip_pool.test.path
   allocation_ip = "12.12.12.21"
+  depends_on    = [nsxt_policy_ip_pool_static_subnet.test]
 }
 
 data "nsxt_policy_realization_info" "realization_info" {

--- a/nsxt/resource_nsxt_policy_tier0_gateway_interface_test.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway_interface_test.go
@@ -288,7 +288,7 @@ func testAccNsxtPolicyTier0InterfaceCheckDestroy(state *terraform.State, display
 	return nil
 }
 
-func testAccNsxtPolicyGatewayInterfaceDeps() string {
+func testAccNsxtPolicyGatewayInterfaceDeps(vlans string) string {
 	return fmt.Sprintf(`
 data "nsxt_policy_edge_cluster" "EC" {
   display_name = "%s"
@@ -301,16 +301,17 @@ data "nsxt_policy_transport_zone" "test" {
 resource "nsxt_policy_vlan_segment" "test" {
   transport_zone_path = data.nsxt_policy_transport_zone.test.path
   display_name        = "interface_test"
-  vlan_ids            = ["11", "12"]
+  vlan_ids            = [%s]
   subnet {
       cidr = "10.2.2.2/24"
   }
-}`, getEdgeClusterName(), getVlanTransportZoneName())
+}`, getEdgeClusterName(), getVlanTransportZoneName(), vlans)
 
 }
 
 func testAccNsxtPolicyTier0InterfaceServiceTemplate(name string, subnet string, mtu string) string {
-	return testAccNsxtPolicyGatewayInterfaceDeps() + fmt.Sprintf(`
+	return testAccNsxtPolicyGatewayInterfaceDeps("11") + fmt.Sprintf(`
+
 resource "nsxt_policy_tier0_gateway" "test" {
   nsx_id            = "%s"
   display_name      = "%s"
@@ -339,7 +340,7 @@ data "nsxt_policy_realization_info" "realization_info" {
 }
 
 func testAccNsxtPolicyTier0InterfaceThinTemplate(name string, subnet string) string {
-	return testAccNsxtPolicyGatewayInterfaceDeps() + fmt.Sprintf(`
+	return testAccNsxtPolicyGatewayInterfaceDeps("11") + fmt.Sprintf(`
 resource "nsxt_policy_tier0_gateway" "test" {
   nsx_id            = "%s"
   display_name      = "%s"
@@ -361,7 +362,7 @@ data "nsxt_policy_realization_info" "realization_info" {
 }
 
 func testAccNsxtPolicyTier0InterfaceTemplateWithID(name string, subnet string) string {
-	return testAccNsxtPolicyGatewayInterfaceDeps() + fmt.Sprintf(`
+	return testAccNsxtPolicyGatewayInterfaceDeps("11") + fmt.Sprintf(`
 data "nsxt_policy_ipv6_ndra_profile" "default" {
   display_name = "default"
 }
@@ -390,7 +391,7 @@ data "nsxt_policy_realization_info" "realization_info" {
 }
 
 func testAccNsxtPolicyTier0InterfaceExternalTemplate(name string, subnet string, mtu string) string {
-	return testAccNsxtPolicyGatewayInterfaceDeps() + fmt.Sprintf(`
+	return testAccNsxtPolicyGatewayInterfaceDeps("11") + fmt.Sprintf(`
 data "nsxt_policy_edge_node" "EN" {
   edge_cluster_path = data.nsxt_policy_edge_cluster.EC.path
   member_index      = 0

--- a/nsxt/resource_nsxt_policy_tier0_gateway_test.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway_test.go
@@ -325,7 +325,7 @@ func TestAccResourceNsxtPolicyTier0Gateway_withVRF(t *testing.T) {
 					resource.TestCheckResourceAttrSet(testResourceName, "path"),
 					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
 					resource.TestCheckResourceAttr(testInterfaceName, "display_name", name),
-					resource.TestCheckResourceAttr(testInterfaceName, "access_vlan_id", "11"),
+					resource.TestCheckResourceAttr(testInterfaceName, "access_vlan_id", "12"),
 				),
 			},
 			{
@@ -338,7 +338,7 @@ func TestAccResourceNsxtPolicyTier0Gateway_withVRF(t *testing.T) {
 					resource.TestCheckResourceAttrSet(testResourceName, "path"),
 					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
 					resource.TestCheckResourceAttr(testInterfaceName, "display_name", updateName),
-					resource.TestCheckResourceAttr(testInterfaceName, "access_vlan_id", "11"),
+					resource.TestCheckResourceAttr(testInterfaceName, "access_vlan_id", "12"),
 				),
 			},
 			{
@@ -640,7 +640,7 @@ func testAccNsxtPolicyTier0WithVRFTemplate(name string, targets bool) string {
         }
             `
 	}
-	return testAccNsxtPolicyGatewayInterfaceDeps() + fmt.Sprintf(`
+	return testAccNsxtPolicyGatewayInterfaceDeps("11, 12") + fmt.Sprintf(`
 resource "nsxt_policy_tier0_gateway" "parent" {
   nsx_id            = "vrf_parent"
   display_name      = "parent"
@@ -656,15 +656,13 @@ resource "nsxt_policy_tier0_gateway" "test" {
   }
 }
 
-resource "nsxt_policy_tier0_gateway_interface" "test-parent" {
+resource "nsxt_policy_tier0_gateway_interface" "parent-loopback" {
   display_name   = "parent interface"
-  type           = "EXTERNAL"
+  type           = "LOOPBACK"
   gateway_path   = nsxt_policy_tier0_gateway.parent.path
-  segment_path   = nsxt_policy_vlan_segment.test.path
   edge_node_path = data.nsxt_policy_edge_node.EN.path
-  subnets        = ["4.4.4.1/24"]
+  subnets        = ["4.4.4.12/24"]
 }
-
 
 data "nsxt_policy_edge_node" "EN" {
   edge_cluster_path = data.nsxt_policy_edge_cluster.EC.path
@@ -678,7 +676,7 @@ resource "nsxt_policy_tier0_gateway_interface" "test" {
   segment_path   = nsxt_policy_vlan_segment.test.path
   edge_node_path = data.nsxt_policy_edge_node.EN.path
   subnets        = ["4.4.4.1/24"]
-  access_vlan_id = 11
+  access_vlan_id = 12
 }
 
 data "nsxt_policy_realization_info" "realization_info" {
@@ -687,7 +685,7 @@ data "nsxt_policy_realization_info" "realization_info" {
 }
 
 func testAccNsxtPolicyTier0WithVRFTearDown() string {
-	return testAccNsxtPolicyGatewayInterfaceDeps() + `
+	return testAccNsxtPolicyGatewayInterfaceDeps("11, 12") + `
 data "nsxt_policy_edge_node" "EN" {
   edge_cluster_path = data.nsxt_policy_edge_cluster.EC.path
   member_index      = 0
@@ -699,12 +697,11 @@ resource "nsxt_policy_tier0_gateway" "parent" {
   edge_cluster_path = data.nsxt_policy_edge_cluster.EC.path
 }
 
-resource "nsxt_policy_tier0_gateway_interface" "test-parent" {
+resource "nsxt_policy_tier0_gateway_interface" "parent-loopback" {
   display_name   = "parent interface"
-  type           = "EXTERNAL"
+  type           = "LOOPBACK"
   gateway_path   = nsxt_policy_tier0_gateway.parent.path
-  segment_path   = nsxt_policy_vlan_segment.test.path
   edge_node_path = data.nsxt_policy_edge_node.EN.path
-  subnets        = ["4.4.4.1/24"]
+  subnets        = ["4.4.4.12/24"]
 }`
 }

--- a/nsxt/resource_nsxt_policy_tier1_gateway_interface_test.go
+++ b/nsxt/resource_nsxt_policy_tier1_gateway_interface_test.go
@@ -227,7 +227,7 @@ func testAccNsxtPolicyTier1InterfaceCheckDestroy(state *terraform.State, display
 }
 
 func testAccNsxtPolicyTier1InterfaceTemplate(name string, subnet string, mtu string) string {
-	return testAccNsxtPolicyGatewayInterfaceDeps() + fmt.Sprintf(`
+	return testAccNsxtPolicyGatewayInterfaceDeps("11") + fmt.Sprintf(`
 resource "nsxt_policy_tier1_gateway" "test" {
   nsx_id            = "%s"
   display_name      = "%s"
@@ -254,7 +254,7 @@ data "nsxt_policy_realization_info" "realization_info" {
 }
 
 func testAccNsxtPolicyTier1InterfaceThinTemplate(name string, subnet string) string {
-	return testAccNsxtPolicyGatewayInterfaceDeps() + fmt.Sprintf(`
+	return testAccNsxtPolicyGatewayInterfaceDeps("11") + fmt.Sprintf(`
 resource "nsxt_policy_tier1_gateway" "test" {
   nsx_id            = "%s"
   display_name      = "%s"
@@ -274,7 +274,7 @@ data "nsxt_policy_realization_info" "realization_info" {
 }
 
 func testAccNsxtPolicyTier1InterfaceTemplateWithID(name string, subnet string) string {
-	return testAccNsxtPolicyGatewayInterfaceDeps() + fmt.Sprintf(`
+	return testAccNsxtPolicyGatewayInterfaceDeps("11") + fmt.Sprintf(`
 data "nsxt_policy_ipv6_ndra_profile" "default" {
   display_name = "default"
 }


### PR DESCRIPTION
In Tier0 Interface, define segment_path as Optional, in order to
allow LOOPBACK interface with no segment.
In addition, new validation introduced by the platform requires
adjustments in acceptance tests.