### PR TITLE
Mark scope as Computed in policy_nat_rule resource

### DIFF
--- a/nsxt/resource_nsxt_policy_nat_rule.go
+++ b/nsxt/resource_nsxt_policy_nat_rule.go
@@ -123,6 +123,7 @@ func resourceNsxtPolicyNATRule() *schema.Resource {
 				Type:        schema.TypeList,
 				Description: "Policy paths to interfaces or labels where the NAT Rule is enforced",
 				Optional:    true,
+				Computed:    true,
 				Elem:        getElemPolicyPathSchema(),
 			},
 		},


### PR DESCRIPTION
Scope can be auto assigned by platform, hence needs to be computed.