### PR TITLE
Allow non-default enforcement point in policy vm

### DIFF
--- a/nsxt/policy_utils.go
+++ b/nsxt/policy_utils.go
@@ -209,3 +209,7 @@ func nsxtPolicyWaitForRealizationStateConf(connector *client.RestConnector, d *s
 
 	return stateConf
 }
+
+func getPolicyEnforcementPointPath() string {
+	return "/infra/sites/default/enforcement-points/" + policyEnforcementPoint
+}

--- a/nsxt/resource_nsxt_policy_vm_tags.go
+++ b/nsxt/resource_nsxt_policy_vm_tags.go
@@ -49,7 +49,8 @@ func listAllPolicyVirtualMachines(connector *client.RestConnector) ([]model.Virt
 
 	for {
 		// NOTE: the search API does not return resource_type of VirtualMachine
-		vms, err := client.List(cursor, nil, &boolFalse, nil, nil, &boolFalse, nil)
+		enforcementPointPath := getPolicyEnforcementPointPath()
+		vms, err := client.List(cursor, &enforcementPointPath, &boolFalse, nil, nil, &boolFalse, nil)
 		if err != nil {
 			return results, err
 		}


### PR DESCRIPTION
Fix nsxt_policy_vm_tags resource to take enforcement point into
account. This fixes VMC use case.