### PR TITLE
Add server_address in policy segment subnet dhcp

### DIFF
--- a/nsxt/resource_nsxt_policy_dhcp_server.go
+++ b/nsxt/resource_nsxt_policy_dhcp_server.go
@@ -50,7 +50,8 @@ func resourceNsxtPolicyDhcpServer() *schema.Resource {
 			},
 			"server_addresses": {
 				Type:        schema.TypeList,
-				Required:    true,
+				Optional:    true,
+				Computed:    true,
 				Description: "DHCP server address in CIDR format",
 				MaxItems:    2,
 				Elem: &schema.Schema{

--- a/nsxt/resource_nsxt_policy_vlan_segment_test.go
+++ b/nsxt/resource_nsxt_policy_vlan_segment_test.go
@@ -115,6 +115,7 @@ func TestAccResourceNsxtPolicyVlanSegment_withDhcp(t *testing.T) {
 	updatedName := fmt.Sprintf("%s-update", name)
 	testResourceName := "nsxt_policy_vlan_segment.test"
 	leaseTimes := []string{"3600", "36000"}
+	preferredTimes := []string{"3200", "32000"}
 	dnsServersV4 := []string{"2.2.2.2", "3.3.3.3"}
 	dnsServersV6 := []string{"2000::2", "3000::3"}
 
@@ -126,7 +127,7 @@ func TestAccResourceNsxtPolicyVlanSegment_withDhcp(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNsxtPolicyVlanSegmentWithDhcpTemplate(name, dnsServersV4[0], dnsServersV6[0], leaseTimes[0]),
+				Config: testAccNsxtPolicyVlanSegmentWithDhcpTemplate(name, dnsServersV4[0], dnsServersV6[0], leaseTimes[0], preferredTimes[0]),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicySegmentExists(testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
@@ -134,6 +135,7 @@ func TestAccResourceNsxtPolicyVlanSegment_withDhcp(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "subnet.0.cidr", "12.12.2.1/24"),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.0.dhcp_v6_config.#", "0"),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.0.dhcp_v4_config.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "subnet.0.dhcp_v4_config.0.server_address", "12.12.2.2/24"),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.0.dhcp_v4_config.0.lease_time", leaseTimes[0]),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.0.dhcp_v4_config.0.dns_servers.#", "1"),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.0.dhcp_v4_config.0.dns_servers.0", dnsServersV4[0]),
@@ -142,8 +144,9 @@ func TestAccResourceNsxtPolicyVlanSegment_withDhcp(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "subnet.1.cidr", "4012::1/64"),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.1.dhcp_v4_config.#", "0"),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.1.dhcp_v6_config.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "subnet.1.dhcp_v6_config.0.server_address", "4012::2/64"),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.1.dhcp_v6_config.0.lease_time", leaseTimes[0]),
-					resource.TestCheckResourceAttr(testResourceName, "subnet.1.dhcp_v6_config.0.preferred_time", leaseTimes[0]),
+					resource.TestCheckResourceAttr(testResourceName, "subnet.1.dhcp_v6_config.0.preferred_time", preferredTimes[0]),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.1.dhcp_v6_config.0.dns_servers.#", "1"),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.1.dhcp_v6_config.0.dns_servers.0", dnsServersV6[0]),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.1.dhcp_v6_config.0.sntp_servers.#", "2"),
@@ -151,7 +154,7 @@ func TestAccResourceNsxtPolicyVlanSegment_withDhcp(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNsxtPolicyVlanSegmentWithDhcpTemplate(updatedName, dnsServersV4[1], dnsServersV6[1], leaseTimes[1]),
+				Config: testAccNsxtPolicyVlanSegmentWithDhcpTemplate(updatedName, dnsServersV4[1], dnsServersV6[1], leaseTimes[1], preferredTimes[1]),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicySegmentExists(testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "display_name", updatedName),
@@ -159,6 +162,7 @@ func TestAccResourceNsxtPolicyVlanSegment_withDhcp(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "subnet.0.cidr", "12.12.2.1/24"),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.0.dhcp_v6_config.#", "0"),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.0.dhcp_v4_config.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "subnet.0.dhcp_v4_config.0.server_address", "12.12.2.2/24"),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.0.dhcp_v4_config.0.lease_time", leaseTimes[1]),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.0.dhcp_v4_config.0.dns_servers.#", "1"),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.0.dhcp_v4_config.0.dns_servers.0", dnsServersV4[1]),
@@ -167,8 +171,9 @@ func TestAccResourceNsxtPolicyVlanSegment_withDhcp(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "subnet.1.cidr", "4012::1/64"),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.1.dhcp_v4_config.#", "0"),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.1.dhcp_v6_config.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "subnet.1.dhcp_v6_config.0.server_address", "4012::2/64"),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.1.dhcp_v6_config.0.lease_time", leaseTimes[1]),
-					resource.TestCheckResourceAttr(testResourceName, "subnet.1.dhcp_v6_config.0.preferred_time", leaseTimes[1]),
+					resource.TestCheckResourceAttr(testResourceName, "subnet.1.dhcp_v6_config.0.preferred_time", preferredTimes[1]),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.1.dhcp_v6_config.0.dns_servers.#", "1"),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.1.dhcp_v6_config.0.dns_servers.0", dnsServersV6[1]),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.1.dhcp_v6_config.0.sntp_servers.#", "2"),
@@ -330,12 +335,16 @@ resource "nsxt_policy_vlan_segment" "test" {
 `, name)
 }
 
-func testAccNsxtPolicyVlanSegmentWithDhcpTemplate(name string, dnsServerV4 string, dnsServerV6 string, lease string) string {
+func testAccNsxtPolicyVlanSegmentWithDhcpTemplate(name string, dnsServerV4 string, dnsServerV6 string, lease string, preferred string) string {
 	return testAccNsxtPolicyVlanSegmentDeps() + fmt.Sprintf(`
 
-resource "nsxt_policy_dhcp_relay" "test" {
-  display_name     = "segment-test"
-  server_addresses = ["4.4.4.2"]
+data "nsxt_policy_edge_cluster" "EC" {
+  display_name = "%s"
+}
+
+resource "nsxt_policy_dhcp_server" "test" {
+  edge_cluster_path = data.nsxt_policy_edge_cluster.EC.path
+  display_name      = "segment-test"
 }
 
 resource "nsxt_policy_vlan_segment" "test" {
@@ -346,8 +355,9 @@ resource "nsxt_policy_vlan_segment" "test" {
   subnet {
     cidr = "12.12.2.1/24"
     dhcp_v4_config {
-        lease_time  = %s
-        dns_servers = ["%s"]
+        server_address = "12.12.2.2/24"
+        lease_time     = %s
+        dns_servers    = ["%s"]
         dhcp_option_121 {
           network  = "2.1.1.0/24"
           next_hop = "2.3.1.3"
@@ -366,10 +376,11 @@ resource "nsxt_policy_vlan_segment" "test" {
   subnet {
     cidr = "4012::1/64"
     dhcp_v6_config {
-        lease_time      = %s
-        preferred_time  = %s
-        dns_servers     = ["%s"]
-        sntp_servers    = ["3001::1", "3001::2"]
+        server_address = "4012::2/64"
+        lease_time     = %s
+        preferred_time = %s
+        dns_servers    = ["%s"]
+        sntp_servers   = ["3001::1", "3001::2"]
         excluded_range {
             start = "4012::400"
             end   = "4012::500"
@@ -381,8 +392,8 @@ resource "nsxt_policy_vlan_segment" "test" {
     }
   }
 
-  dhcp_config_path = nsxt_policy_dhcp_relay.test.path
+  dhcp_config_path = nsxt_policy_dhcp_server.test.path
 
 }
-`, name, lease, dnsServerV4, lease, lease, dnsServerV6)
+`, getEdgeClusterName(), name, lease, dnsServerV4, lease, preferred, dnsServerV6)
 }

--- a/website/docs/r/policy_dhcp_server.html.markdown
+++ b/website/docs/r/policy_dhcp_server.html.markdown
@@ -9,7 +9,7 @@ description: A resource to configure a DHCP Servers in NSX-T.
 
 This resource provides a method for the management of a DHCP Server configurations.
 This resource is supported with NSX 3.0.0 onwards.
- 
+
 ## Example Usage
 
 ```hcl
@@ -32,8 +32,8 @@ The following arguments are supported:
 * `nsx_id` - (Optional) The NSX ID of this resource. If set, this ID will be used to create the resource.
 * `edge_cluster_path` - (Optional) The Policy path to the edge cluster for this DHCP Server.
 * `lease_time` - (Optional) IP address lease time in seconds. Valid values from `60` to `4294967295`. Default is `86400`.
-* `preferred_edge_paths` - (Optional) Policy paths to edge nodes. The first edge node is assigned as active edge, and second one as standby edge. 
-* `server_addresses` - (Required) DHCP server address in CIDR format. At most 2 supported; one IPv4 and one IPv6 address.
+* `preferred_edge_paths` - (Optional) Policy paths to edge nodes. The first edge node is assigned as active edge, and second one as standby edge.
+* `server_addresses` - (Optional) DHCP server address in CIDR format. At most 2 supported; one IPv4 and one IPv6 address. Server address can also be specified on segment subnet level.
 
 
 ## Attributes Reference

--- a/website/docs/r/policy_segment.html.markdown
+++ b/website/docs/r/policy_segment.html.markdown
@@ -22,7 +22,8 @@ resource "nsxt_policy_segment" "segment1" {
       dhcp_ranges = ["12.12.2.100-12.12.2.160"]
 
       dhcp_v4_config {
-        lease_time = 36000
+        server_address = "12.12.2.2/24"
+        lease_time     = 36000
 
         dhcp_option_121 {
           network  = "6.6.6.0/24"
@@ -60,6 +61,7 @@ The following arguments are supported:
   * `cidr` - (Required) Gateway IP address CIDR. This argument can not be changed if DHCP is enabled for the subnet.
   * `dhcp_ranges` - (Optional) List of DHCP address ranges for dynamic IP allocation.
   * `dhcp_v4_config` - (Optional) DHCPv4 config for IPv4 subnet. This clause is supported with NSX 3.0.0 onwards.
+    * `server_address` - (Optional) IP address of the DHCP server in CIDR format. This attribute is required if segment has provided dhcp_config_path and it represents a DHCP server config.
     * `dns_servers` - (Optional) List of IP addresses of DNS servers for the subnet.
     * `lease_time`  - (Optional) DHCP lease time in seconds.
     * `dhcp_option_121` - (Optional) DHCP classless static routes.
@@ -69,6 +71,7 @@ The following arguments are supported:
       * `code` - (Required) DHCP option code. Valid values are from 0 to 255.
       * `values` - (Required) List of DHCP option values.
   * `dhcp_v6_config` - (Optional) DHCPv6 config for IPv6 subnet. This clause is supported with NSX 3.0.0 onwards.
+    * `server_address` - (Optional) IP address of the DHCP server in CIDR format. This attribute is required if segment has provided dhcp_config_path and it represents a DHCP server config.
     * `dns_servers` - (Optional) List of IP addresses of DNS servers for the subnet.
     * `lease_time`  - (Optional) DHCP lease time in seconds.
     * `preferred_time` - (Optional) The time interval in seconds, in which the prefix is advertised as preferred.

--- a/website/docs/r/policy_vlan_segment.html.markdown
+++ b/website/docs/r/policy_vlan_segment.html.markdown
@@ -24,7 +24,8 @@ resource "nsxt_policy_vlan_segment" "vlansegment1" {
     dhcp_ranges = ["12.12.2.100-12.12.2.160"]
 
     dhcp_v4_config {
-      lease_time = 36000
+      server_address = "12.12.2.2/24"
+      lease_time     = 36000
 
       dhcp_option_121 {
         network  = "6.6.6.0/24"
@@ -61,6 +62,7 @@ The following arguments are supported:
   * `cidr` - (Required) Gateway IP address CIDR.
   * `dhcp_ranges` - (Optional) List of DHCP address ranges for dynamic IP allocation.
   * `dhcp_v4_config` - (Optional) DHCPv4 config for IPv4 subnet. This attribute is supported with NSX 3.0.0 onwards.
+    * `server_address` - (Optional) IP address of the DHCP server in CIDR format. This attribute is required if segment has provided dhcp_config_path and it represents a DHCP server config.
     * `dns_servers` - (Optional) List of IP addresses of DNS servers for the subnet.
     * `lease_time`  - (Optional) DHCP lease time in seconds.
     * `dhcp_option_121` - (Optional) DHCP classless static routes.
@@ -70,6 +72,7 @@ The following arguments are supported:
       * `code` - (Required) DHCP option code. Valid values are from 0 to 255.
       * `values` - (Required) List of DHCP option values.
   * `dhcp_v6_config` - (Optional) DHCPv6 config for IPv6 subnet. This attribute is supported with NSX 3.0.0 onwards.
+    * `server_address` - (Optional) IP address of the DHCP server in CIDR format. This attribute is required if segment has provided dhcp_config_path and it represents a DHCP server config.
     * `dns_servers` - (Optional) List of IP addresses of DNS servers for the subnet.
     * `lease_time`  - (Optional) DHCP lease time in seconds.
     * `preferred_time` - (Optional) The time interval in seconds, in which the prefix is advertised as preferred.


### PR DESCRIPTION
Platform now allows to specify server_address on subnet level.
Server addresses are no longer mandatory on server config level.