### PR TITLE
Expose pool_allocation and qos settings on Tier1

### DIFF
--- a/nsxt/data_source_nsxt_policy_gateway_qos_profile.go
+++ b/nsxt/data_source_nsxt_policy_gateway_qos_profile.go
@@ -1,0 +1,81 @@
+/* Copyright © 2019 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	"strings"
+)
+
+func dataSourceNsxtPolicyGatewayQosProfile() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceNsxtPolicyGatewayQosProfileRead,
+
+		Schema: map[string]*schema.Schema{
+			"id":           getDataSourceIDSchema(),
+			"display_name": getDataSourceDisplayNameSchema(),
+			"description":  getDataSourceDescriptionSchema(),
+			"path":         getPathSchema(),
+		},
+	}
+}
+
+func dataSourceNsxtPolicyGatewayQosProfileRead(d *schema.ResourceData, m interface{}) error {
+	connector := getPolicyConnector(m)
+	client := infra.NewDefaultGatewayQosProfilesClient(connector)
+
+	objID := d.Get("id").(string)
+	objName := d.Get("display_name").(string)
+	var obj model.GatewayQosProfile
+	if objID != "" {
+		// Get by id
+		objGet, err := client.Get(objID)
+		if err != nil {
+			return handleDataSourceReadError(d, "GatewayQosProfile", objID, err)
+		}
+		obj = objGet
+	} else if objName == "" {
+		return fmt.Errorf("Error obtaining GatewayQosProfile ID or name during read")
+	} else {
+		// Get by full name/prefix
+		includeMarkForDeleteObjectsParam := false
+		objList, err := client.List(nil, &includeMarkForDeleteObjectsParam, nil, nil, nil, nil)
+		if err != nil {
+			return handleListError("GatewayQosProfile", err)
+		}
+		// go over the list to find the correct one (prefer a perfect match. If not - prefix match)
+		var perfectMatch []model.GatewayQosProfile
+		var prefixMatch []model.GatewayQosProfile
+		for _, objInList := range objList.Results {
+			if strings.HasPrefix(*objInList.DisplayName, objName) {
+				prefixMatch = append(prefixMatch, objInList)
+			}
+			if *objInList.DisplayName == objName {
+				perfectMatch = append(perfectMatch, objInList)
+			}
+		}
+		if len(perfectMatch) > 0 {
+			if len(perfectMatch) > 1 {
+				return fmt.Errorf("Found multiple GatewayQosProfiles with name '%s'", objName)
+			}
+			obj = perfectMatch[0]
+		} else if len(prefixMatch) > 0 {
+			if len(prefixMatch) > 1 {
+				return fmt.Errorf("Found multiple GatewayQosProfiles with name starting with '%s'", objName)
+			}
+			obj = prefixMatch[0]
+		} else {
+			return fmt.Errorf("GatewayQosProfile with name '%s' was not found", objName)
+		}
+	}
+
+	d.SetId(*obj.Id)
+	d.Set("display_name", obj.DisplayName)
+	d.Set("description", obj.Description)
+	d.Set("path", obj.Path)
+	return nil
+}

--- a/nsxt/data_source_nsxt_policy_gateway_qos_profile_test.go
+++ b/nsxt/data_source_nsxt_policy_gateway_qos_profile_test.go
@@ -1,0 +1,99 @@
+/* Copyright © 2019 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	"testing"
+)
+
+func TestAccDataSourceNsxtPolicyGatewayQosProfile_basic(t *testing.T) {
+	name := "terraform_test"
+	testResourceName := "data.nsxt_policy_gateway_qos_profile.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccDataSourceNsxtPolicyGatewayQosProfileDeleteByName(name)
+		},
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					if err := testAccDataSourceNsxtPolicyGatewayQosProfileCreate(name); err != nil {
+						panic(err)
+					}
+				},
+				Config: testAccNsxtPolicyGatewayQosProfileReadTemplate(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
+					resource.TestCheckResourceAttr(testResourceName, "description", name),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+				),
+			},
+			{
+				Config: testAccNsxtPolicyEmptyTemplate(),
+			},
+		},
+	})
+}
+
+func testAccDataSourceNsxtPolicyGatewayQosProfileCreate(name string) error {
+	connector, err := testAccGetPolicyConnector()
+	if err != nil {
+		return fmt.Errorf("Error during test client initialization: %v", err)
+	}
+	client := infra.NewDefaultGatewayQosProfilesClient(connector)
+
+	displayName := name
+	description := name
+	obj := model.GatewayQosProfile{
+		Description: &description,
+		DisplayName: &displayName,
+	}
+
+	// Generate a random ID for the resource
+	id := newUUID()
+
+	err = client.Patch(id, obj, nil)
+	if err != nil {
+		return fmt.Errorf("Error during GatewayQosProfile creation: %v", err)
+	}
+	return nil
+}
+
+func testAccDataSourceNsxtPolicyGatewayQosProfileDeleteByName(name string) error {
+	connector, err := testAccGetPolicyConnector()
+	if err != nil {
+		return fmt.Errorf("Error during test client initialization: %v", err)
+	}
+	client := infra.NewDefaultGatewayQosProfilesClient(connector)
+
+	// Find the object by name
+	objList, err := client.List(nil, nil, nil, nil, nil, nil)
+	if err != nil {
+		return handleListError("GatewayQosProfile", err)
+	}
+	for _, objInList := range objList.Results {
+		if *objInList.DisplayName == name {
+			err := client.Delete(*objInList.Id, nil)
+			if err != nil {
+				return fmt.Errorf("Error during GatewayQosProfile deletion: %v", err)
+			}
+			return nil
+		}
+	}
+	return fmt.Errorf("Error while deleting GatewayQosProfile '%s': resource not found", name)
+}
+
+func testAccNsxtPolicyGatewayQosProfileReadTemplate(name string) string {
+	return fmt.Sprintf(`
+data "nsxt_policy_gateway_qos_profile" "test" {
+  display_name = "%s"
+}`, name)
+}

--- a/nsxt/provider.go
+++ b/nsxt/provider.go
@@ -163,6 +163,7 @@ func Provider() terraform.ResourceProvider {
 			"nsxt_policy_qos_profile":              dataSourceNsxtPolicyQosProfile(),
 			"nsxt_policy_ipv6_ndra_profile":        dataSourceNsxtPolicyIpv6NdraProfile(),
 			"nsxt_policy_ipv6_dad_profile":         dataSourceNsxtPolicyIpv6DadProfile(),
+			"nsxt_policy_gateway_qos_profile":      dataSourceNsxtPolicyGatewayQosProfile(),
 			"nsxt_policy_segment_security_profile": dataSourceNsxtPolicySegmentSecurityProfile(),
 			"nsxt_policy_mac_discovery_profile":    dataSourceNsxtPolicyMacDiscoveryProfile(),
 			"nsxt_policy_vm":                       dataSourceNsxtPolicyVM(),

--- a/nsxt/resource_nsxt_policy_tier1_gateway_test.go
+++ b/nsxt/resource_nsxt_policy_tier1_gateway_test.go
@@ -224,7 +224,7 @@ func TestAccResourceNsxtPolicyTier1Gateway_withId(t *testing.T) {
 }
 func TestAccResourceNsxtPolicyTier1Gateway_withQos(t *testing.T) {
 	name := "test-nsx-policy-tier1"
-        profileName := "test-nsx-qos-profile"
+	profileName := "test-nsx-qos-profile"
 	updateName := fmt.Sprintf("%s-update", name)
 	testResourceName := "nsxt_policy_tier1_gateway.test"
 
@@ -232,24 +232,24 @@ func TestAccResourceNsxtPolicyTier1Gateway_withQos(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-                        if err := testAccDataSourceNsxtPolicyGatewayQosProfileDeleteByName(profileName); err != nil {
-                            return err
-                        }
+			if err := testAccDataSourceNsxtPolicyGatewayQosProfileDeleteByName(profileName); err != nil {
+				return err
+			}
 			return testAccNsxtPolicyTier1CheckDestroy(state, name)
 		},
 		Steps: []resource.TestStep{
 			{
-                                PreConfig: func() {
-                                        if err := testAccDataSourceNsxtPolicyGatewayQosProfileCreate(profileName); err != nil {
-                                            panic(err)
-                                        }
-                                },
+				PreConfig: func() {
+					if err := testAccDataSourceNsxtPolicyGatewayQosProfileCreate(profileName); err != nil {
+						panic(err)
+					}
+				},
 				Config: testAccNsxtPolicyTier1TemplateWithQos(name, profileName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicyTier1Exists(testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
-                                        resource.TestCheckResourceAttrSet(testResourceName, "ingress_qos_profile_path"),
-                                        resource.TestCheckResourceAttrSet(testResourceName, "egress_qos_profile_path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "ingress_qos_profile_path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "egress_qos_profile_path"),
 					resource.TestCheckResourceAttr(realizationResourceName, "state", "REALIZED"),
 				),
 			},
@@ -258,14 +258,14 @@ func TestAccResourceNsxtPolicyTier1Gateway_withQos(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicyTier1Exists(testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "display_name", updateName),
-                                        resource.TestCheckResourceAttr(testResourceName, "ingress_qos_profile_path", ""),
-                                        resource.TestCheckResourceAttr(testResourceName, "egress_qos_profile_path", ""),
+					resource.TestCheckResourceAttr(testResourceName, "ingress_qos_profile_path", ""),
+					resource.TestCheckResourceAttr(testResourceName, "egress_qos_profile_path", ""),
 					resource.TestCheckResourceAttr(realizationResourceName, "state", "REALIZED"),
 				),
 			},
-                        {
-                                Config: testAccNsxtPolicyEmptyTemplate(),
-                        },
+			{
+				Config: testAccNsxtPolicyEmptyTemplate(),
+			},
 		},
 	})
 }

--- a/website/docs/d/policy_gateway_qos_profile.html.markdown
+++ b/website/docs/d/policy_gateway_qos_profile.html.markdown
@@ -1,0 +1,32 @@
+---
+layout: "nsxt"
+page_title: "NSXT: policy_gateway_qos_profile"
+sidebar_current: "docs-nsxt-datasource-policy-gateway-qos-profile"
+description: Policy GatewayQosProfile data source.
+---
+
+# nsxt_policy_gateway_qos_profile
+
+This data source provides information about policy GatewayQosProfile configured in NSX.
+
+## Example Usage
+
+```hcl
+data "nsxt_policy_gateway_qos_profile" "test" {
+  display_name = "gateway-qos-profile1"
+}
+```
+
+## Argument Reference
+
+* `id` - (Optional) The ID of GatewayQosProfile to retrieve.
+
+* `display_name` - (Optional) The Display Name prefix of the GatewayQosProfile to retrieve.
+
+## Attributes Reference
+
+In addition to arguments listed above, the following attributes are exported:
+
+* `description` - The description of the resource.
+
+* `path` - The NSX path of the policy resource.

--- a/website/docs/r/policy_tier1_gateway.html.markdown
+++ b/website/docs/r/policy_tier1_gateway.html.markdown
@@ -32,6 +32,7 @@ resource "nsxt_policy_tier1_gateway" "tier1_gw" {
   force_whitelisting        = "true"
   tier0_path                = data.nsxt_policy_tier0_gateway.T0.path
   route_advertisement_types = ["TIER1_STATIC_ROUTES", "TIER1_CONNECTED"]
+  pool_allocation           = "ROUTING"
 
   tag {
     scope = "color"
@@ -67,12 +68,15 @@ The following arguments are supported:
 * `ipv6_ndra_profile_path` - (Optional) Policy path to IPv6 NDRA profile.
 * `ipv6_dad_profile_path` - (Optional) Policy path to IPv6 DAD profile.
 * `dhcp_config_path` - (Optional) Policy path to DHCP server or relay configuration to use for this gateway.
+* `pool_allocation` - (Optional) Size of edge node allocation at for routing and load balancer service to meet performance and scalability requirements, one of `ROUTING`, `LB_SMALL`, `LB_MEDIUM`, `LB_LARGE`, `LB_XLARGE`. Default is `ROUTING`. Changing this attribute would force new resource.
 * `route_advertisement_rule` - (Optional) List of rules for routes advertisement:
   * `name` - (Required) The name of the rule.
   * `action` - (Required) Action to advertise filtered routes to the connected Tier0 gateway. PERMIT (which is the default): Enables the advertisement, DENY: Disables the advertisement.
   * `subnets` - (Required) list of network CIDRs to be routed.
   * `prefix_operator` - (Optional) Prefix operator to apply on subnets. GE prefix operator (which is the default|) filters all the routes having network subset of any of the networks configured in Advertise rule. EQ prefix operator filter all the routes having network equal to any of the network configured in Advertise rule.The name of the rule.
-  * `route_advertisement_types` - (Optional) Enable different types of route advertisements: TIER1_STATIC_ROUTES, TIER1_
+* `route_advertisement_types` - (Optional) List of desired types of route advertisements, supported values: `TIER1_STATIC_ROUTES`, `TIER1_CONNECTED`, `TIER1_NAT`, `TIER1_LB_VIP`, `TIER1_LB_SNAT`, `TIER1_DNS_FORWARDER_IP`, `TIER1_IPSEC_LOCAL_ENDPOINT`.
+* `ingress_qos_profile_path` - (Optional) QoS Profile path for ingress traffic on link connected to Tier0 gateway.
+* `egress_qos_profile_path` - (Optional) QoS Profile path for egress traffic on link connected to Tier0 gateway.
 
 ## Attributes Reference
 

--- a/website/nsxt.erb
+++ b/website/nsxt.erb
@@ -85,6 +85,9 @@
                         <li<%= sidebar_current("docs-nsxt-datasource-policy-ipv6-dad-profile") %>>
                             <a href="/docs/providers/nsxt/d/policy_ipv6_dad_profile.html">nsxt_policy_ipv6_dad_profile</a>
                         </li>
+                        <li<%= sidebar_current("docs-nsxt-datasource-policy-gateway-qos-profile") %>>
+                            <a href="/docs/providers/nsxt/d/policy_gateway_qos_profile.html">nsxt_policy_gateway_qos_profile</a>
+                        </li>
                         <li<%= sidebar_current("docs-nsxt-datasource-policy-segment-security-profile") %>>
                             <a href="/docs/providers/nsxt/d/policy_segment_security_profile.html">nsxt_policy_segment_security_profile</a>
                         </li>


### PR DESCRIPTION
Expose pool_allocation, ingress_qos_profile_path,
egress_qos_profile_path attributes on nsxt_policy_tier1_gateway.
In addition, expose nsxt_policy_gateway_qos_profile data source.