### PR TITLE
Optimize vm tag resources

### DIFF
--- a/nsxt/resource_nsxt_policy_vm_tags.go
+++ b/nsxt/resource_nsxt_policy_vm_tags.go
@@ -35,7 +35,7 @@ func resourceNsxtPolicyVMTags() *schema.Resource {
 				Description: "Instance id",
 				Required:    true,
 			},
-			"tag": getTagsSchema(),
+			"tag": getRequiredTagsSchema(),
 		},
 	}
 }

--- a/nsxt/resource_nsxt_policy_vm_tags_test.go
+++ b/nsxt/resource_nsxt_policy_vm_tags_test.go
@@ -38,12 +38,7 @@ func TestAccResourceNsxtPolicyVMTags_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNSXPolicyVMTagsRemoveTemplate(vmID),
-				Check: resource.ComposeTestCheckFunc(
-					testAccNSXPolicyVMTagsCheckExists(testResourceName),
-					resource.TestCheckResourceAttr(testResourceName, "tag.#", "0"),
-					resource.TestCheckResourceAttr(testResourceName, "instance_id", vmID),
-				),
+				Config: testAccNsxtPolicyEmptyTemplate(),
 			},
 		},
 	})
@@ -68,6 +63,9 @@ func TestAccResourceNsxtPolicyVMTags_import_basic(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"instance_id"},
+			},
+			{
+				Config: testAccNsxtPolicyEmptyTemplate(),
 			},
 		},
 	})
@@ -143,12 +141,5 @@ resource "nsxt_policy_vm_tags" "test" {
     scope = "scope2"
     tag   = "tag2"
   }
-}`, instanceID)
-}
-
-func testAccNSXPolicyVMTagsRemoveTemplate(instanceID string) string {
-	return fmt.Sprintf(`
-resource "nsxt_policy_vm_tags" "test" {
-  instance_id = "%s"
 }`, instanceID)
 }

--- a/nsxt/utils.go
+++ b/nsxt/utils.go
@@ -87,11 +87,12 @@ func getRevisionSchema() *schema.Schema {
 }
 
 // utilities to define & handle tags
-func getTagsSchemaInternal(forceNew bool) *schema.Schema {
+func getTagsSchemaInternal(required bool, forceNew bool) *schema.Schema {
 	return &schema.Schema{
 		Type:        schema.TypeSet,
 		Description: "Set of opaque identifiers meaningful to the user",
-		Optional:    true,
+		Optional:    !required,
+		Required:    required,
 		ForceNew:    forceNew,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
@@ -112,11 +113,15 @@ func getTagsSchemaInternal(forceNew bool) *schema.Schema {
 
 // utilities to define & handle tags
 func getTagsSchema() *schema.Schema {
-	return getTagsSchemaInternal(false)
+	return getTagsSchemaInternal(false, false)
+}
+
+func getRequiredTagsSchema() *schema.Schema {
+	return getTagsSchemaInternal(true, false)
 }
 
 func getTagsSchemaForceNew() *schema.Schema {
-	return getTagsSchemaInternal(true)
+	return getTagsSchemaInternal(false, true)
 }
 
 func getCustomizedTagsFromSchema(d *schema.ResourceData, schemaName string) []common.Tag {


### PR DESCRIPTION
* Make tags required in policy resource, since its the only
attribute that can be set
* Avoid update backend call if there is no change in corresponding
configuration
* Avoid update backend call in delete function if there were no
tags to provider config