### PR TITLE
Allow global-infra in policy path validation

### DIFF
--- a/nsxt/policy_utils.go
+++ b/nsxt/policy_utils.go
@@ -124,7 +124,7 @@ func isPolicyPath(policyPath string) bool {
 	} else if pathSegs[0] != "" || pathSegs[len(pathSegs)-1] == "" {
 		return false
 	} else if !strings.Contains(pathSegs[1], "infra") {
-                // must be infra or global-infra as of now
+		// must be infra or global-infra as of now
 		return false
 	}
 	return true

--- a/nsxt/policy_utils.go
+++ b/nsxt/policy_utils.go
@@ -123,7 +123,8 @@ func isPolicyPath(policyPath string) bool {
 		return false
 	} else if pathSegs[0] != "" || pathSegs[len(pathSegs)-1] == "" {
 		return false
-	} else if pathSegs[1] != "infra" {
+	} else if !strings.Contains(pathSegs[1], "infra") {
+                // must be infra or global-infra as of now
 		return false
 	}
 	return true


### PR DESCRIPTION
With policy global manager, policy path can start with global-infra.
We need to allow referencing global policy objects in policy paths.