### PR TITLE
Re-enable VMC

### DIFF
--- a/nsxt/provider.go
+++ b/nsxt/provider.go
@@ -119,20 +119,18 @@ func Provider() terraform.ResourceProvider {
 				Description: "Treat partial success status as success",
 				DefaultFunc: schema.EnvDefaultFunc("NSXT_TOLERATE_PARTIAL_SUCCESS", false),
 			},
-			/*
-				"vmc_auth_host": {
-					Type:        schema.TypeString,
-					Optional:    true,
-					Description: "URL for VMC authorization service (CSP)",
-					DefaultFunc: schema.EnvDefaultFunc("NSXT_VMC_AUTH_HOST", "console.cloud.vmware.com/csp/gateway/am/api/auth/api-tokens/authorize"),
-				},
-				"vmc_token": {
-					Type:        schema.TypeString,
-					Optional:    true,
-					Description: "Long-living API token for VMC authorization",
-					DefaultFunc: schema.EnvDefaultFunc("NSXT_VMC_TOKEN", nil),
-				},
-			*/
+			"vmc_auth_host": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "URL for VMC authorization service (CSP)",
+				DefaultFunc: schema.EnvDefaultFunc("NSXT_VMC_AUTH_HOST", "console.cloud.vmware.com/csp/gateway/am/api/auth/api-tokens/authorize"),
+			},
+			"vmc_token": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Long-living API token for VMC authorization",
+				DefaultFunc: schema.EnvDefaultFunc("NSXT_VMC_TOKEN", nil),
+			},
 			"enforcement_point": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -285,12 +283,10 @@ func providerConnectivityCheck(nsxClient *nsxt.APIClient) error {
 func configureNsxtClient(d *schema.ResourceData) (*nsxt.APIClient, error) {
 	clientAuthCertFile := d.Get("client_auth_cert_file").(string)
 	clientAuthKeyFile := d.Get("client_auth_key_file").(string)
-	vmcToken := d.Get("vmc_token")
-	if vmcToken != nil {
+	vmcToken := d.Get("vmc_token").(string)
 
-		if len(vmcToken.(string)) > 0 {
-			return nil, nil
-		}
+	if len(vmcToken) > 0 {
+		return nil, nil
 	}
 
 	needCreds := true
@@ -452,16 +448,8 @@ func configurePolicyConnectorData(d *schema.ResourceData, clients *nsxtClients) 
 	hostIP := d.Get("host").(string)
 	username := d.Get("username").(string)
 	password := d.Get("password").(string)
-	vmcAccessTokenAttr := d.Get("vmc_token")
-	vmcAuthHostAttr := d.Get("vmc_auth_host")
-	vmcAccessToken := ""
-	vmcAuthHost := ""
-	if vmcAccessTokenAttr != nil {
-		vmcAccessToken = vmcAccessTokenAttr.(string)
-	}
-	if vmcAuthHostAttr != nil {
-		vmcAuthHost = vmcAuthHostAttr.(string)
-	}
+	vmcAccessToken := d.Get("vmc_token").(string)
+	vmcAuthHost := d.Get("vmc_auth_host").(string)
 	insecure := d.Get("allow_unverified_ssl").(bool)
 	clientAuthCertFile := d.Get("client_auth_cert_file").(string)
 	clientAuthKeyFile := d.Get("client_auth_key_file").(string)

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -109,6 +109,20 @@ provider "nsxt" {
 
 ```
 
+### VMC Environment Example
+
+Note that only a limited subset of policy resources are supported with VMC.
+
+```hcl
+provider "nsxt" {
+  host                 = "x-54-200-54-5.rp.vmwarevmc.com/vmc/reverse-proxy/api/orgs/b003c3a5-3f68-4a8c-a74f-f79a0625da17/sddcs/d2f43050-f4e2-4989-ab52-2eb0b89d8487/sks-nsxt-manager"
+  vmc_token            = "5aVZEj6dJN1bQ6ZheakMyV0Qbj7P65sa2pYuhgx7Mp5glvgCkFKHcGxy3KmslllT"
+  allow_unverified_ssl = true
+  enforcement_point    = "vmc-enforcementpoint"
+}
+
+```
+
 ## Argument Reference
 
 The following arguments are used to configure the VMware NSX-T Provider:
@@ -153,8 +167,16 @@ The following arguments are used to configure the VMware NSX-T Provider:
   `NSXT_REMOTE_AUTH` environment variable.
 * `tolerate_partial_success` - (Optional) Setting this flag to true would treat
   partially succesful realization as valid state and not fail apply.
+* `vmc_token` - (Optional) Long-lived API token for authenticating with VMware
+  Cloud Services APIs. This token will be used to short-lived token that is
+  needed to communicate with NSX Manager in VMC environment.
+  Note that only subset of policy resources are supported with VMC environment.
+* `vmc_auth_host` - (Optional) URL for VMC authorization service that is used
+  to obtain short-lived token for NSX manager access. Defaults to VMC
+  console authorization URL.
 * `enforcement_point` - (Optional) Enforcement point, mostly relevant for policy
-  data sources.
+  data sources. For VMC environment, this should be set to `vmc-enforcementpoint`.
+  For on-prem deployments, this setting should not be specified.
 
 ## NSX Logical Networking
 

--- a/website/docs/r/policy_gateway_policy.html.markdown
+++ b/website/docs/r/policy_gateway_policy.html.markdown
@@ -45,7 +45,7 @@ The following arguments are supported:
 * `display_name` - (Required) Display name of the resource.
 * `category` - (Required) The category to use for priority of this Gateway Policy. Must be one of: `Emergency`, `SystemRules`, `SharedPreRules`, `LocalGatewayRules`, `AutoServiceRules` and `Default`.
 * `description` - (Optional) Description of the resource.
-* `domain` - (Optional) The domain to use for the Gateway Policy. This domain must already exist.
+* `domain` - (Optional) The domain to use for the Gateway Policy. This domain must already exist. For VMware Cloud on AWS use `cgw`.
 * `tag` - (Optional) A list of scope + tag pairs to associate with this Gateway Policy.
 * `nsx_id` - (Optional) The NSX ID of this resource. If set, this ID will be used to create the Gateway Policy resource.
 * `comments` - (Optional) Comments for this Gateway Policy including lock/unlock comments.

--- a/website/docs/r/policy_group.html.markdown
+++ b/website/docs/r/policy_group.html.markdown
@@ -49,7 +49,7 @@ The following arguments are supported:
 
 * `display_name` - (Required) Display name of the resource.
 * `description` - (Optional) Description of the resource.
-* `domain` - (Optional) The domain to use for the Group. This domain must already exist.
+* `domain` - (Optional) The domain to use for the Group. This domain must already exist. For VMware Cloud on AWS use `cgw`.
 * `tag` - (Optional) A list of scope + tag pairs to associate with this Group.
 * `nsx_id` - (Optional) The NSX ID of this resource. If set, this ID will be used to create the group resource.
 * `criteria` - (Optional) A repeatable block to specify criteria for members of this Group. If more than 1 criteria block is specified, it must be separated by a `conjunction`. In a `criteria` block the following membership selection expressions can be used:

--- a/website/docs/r/policy_security_policy.html.markdown
+++ b/website/docs/r/policy_security_policy.html.markdown
@@ -49,7 +49,7 @@ The following arguments are supported:
 
 * `display_name` - (Required) Display name of the resource.
 * `description` - (Optional) Description of the resource.
-* `domain` - (Optional) The domain to use for the resource. This domain must already exist.
+* `domain` - (Optional) The domain to use for the resource. This domain must already exist. For VMware Cloud on AWS use `cgw`.
 * `tag` - (Optional) A list of scope + tag pairs to associate with this policy.
 * `nsx_id` - (Optional) The NSX ID of this resource. If set, this ID will be used to create the resource.
 * `category` - (Required) Category of this policy, one of `Ethernet`, `Emergency`, `Infrastructure`, `Environment`, `Application`.


### PR DESCRIPTION
This reverts commit 07fb1d166c3540edd51ba3a6561d0a1144e79daf.
VMC was disabled before 2.0.0 release since the feature is not
officially supported. This change re-enables VMC support.