### PR TITLE
Add the correct type of security policy rule tag

### DIFF
--- a/nsxt/resource_nsxt_policy_gateway_policy_test.go
+++ b/nsxt/resource_nsxt_policy_gateway_policy_test.go
@@ -22,6 +22,8 @@ func TestAccResourceNsxtPolicyGatewayPolicy_basic(t *testing.T) {
 	proto1 := "IPV4"
 	proto2 := "IPV4_IPV6"
 	defaultAction := "ALLOW"
+	tag1 := "abc"
+	tag2 := "def"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -64,7 +66,7 @@ func TestAccResourceNsxtPolicyGatewayPolicy_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNsxtPolicyGatewayPolicyWithRule(updatedName, direction1, proto1),
+				Config: testAccNsxtPolicyGatewayPolicyWithRule(updatedName, direction1, proto1, tag1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicyGatewayPolicyExists(testResourceName, defaultDomain),
 					resource.TestCheckResourceAttr(testResourceName, "display_name", updatedName),
@@ -81,10 +83,12 @@ func TestAccResourceNsxtPolicyGatewayPolicy_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "rule.0.direction", direction1),
 					resource.TestCheckResourceAttr(testResourceName, "rule.0.ip_version", proto1),
 					resource.TestCheckResourceAttr(testResourceName, "rule.0.action", defaultAction),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.log_label", tag1),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.tag.#", "1"),
 				),
 			},
 			{
-				Config: testAccNsxtPolicyGatewayPolicyWithRule(updatedName, direction2, proto2),
+				Config: testAccNsxtPolicyGatewayPolicyWithRule(updatedName, direction2, proto2, tag2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicyGatewayPolicyExists(testResourceName, defaultDomain),
 					resource.TestCheckResourceAttr(testResourceName, "display_name", updatedName),
@@ -101,6 +105,8 @@ func TestAccResourceNsxtPolicyGatewayPolicy_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "rule.0.direction", direction2),
 					resource.TestCheckResourceAttr(testResourceName, "rule.0.ip_version", proto2),
 					resource.TestCheckResourceAttr(testResourceName, "rule.0.action", defaultAction),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.log_label", tag2),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.tag.#", "1"),
 				),
 			},
 		},
@@ -309,7 +315,7 @@ resource "nsxt_policy_gateway_policy" "test" {
 }`, name, comments)
 }
 
-func testAccNsxtPolicyGatewayPolicyWithRule(name string, direction string, protocol string) string {
+func testAccNsxtPolicyGatewayPolicyWithRule(name string, direction string, protocol string, ruleTag string) string {
 	return fmt.Sprintf(`
 resource "nsxt_policy_tier1_gateway" "gwt1test" {
   display_name      = "tf-t1-gw"
@@ -333,10 +339,16 @@ resource "nsxt_policy_gateway_policy" "test" {
   rule {
     display_name = "%s"
     direction    = "%s"
-    ip_version  = "%s"
+    ip_version   = "%s"
     scope        = [nsxt_policy_tier1_gateway.gwt1test.path]
+    log_label    = "%s"
+
+    tag {
+      scope = "color"
+      tag   = "blue"
+    }
   }
-}`, name, name, direction, protocol)
+}`, name, name, direction, protocol, ruleTag)
 }
 
 //TODO: add  profiles when available

--- a/nsxt/resource_nsxt_policy_security_policy_test.go
+++ b/nsxt/resource_nsxt_policy_security_policy_test.go
@@ -22,6 +22,8 @@ func TestAccResourceNsxtPolicySecurityPolicy_basic(t *testing.T) {
 	proto1 := "IPV4"
 	proto2 := "IPV4_IPV6"
 	defaultAction := "ALLOW"
+	tag1 := "abc"
+	tag2 := "def"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -66,7 +68,7 @@ func TestAccResourceNsxtPolicySecurityPolicy_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNsxtPolicySecurityPolicyWithRule(updatedName, direction1, proto1),
+				Config: testAccNsxtPolicySecurityPolicyWithRule(updatedName, direction1, proto1, tag1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicySecurityPolicyExists(testResourceName, defaultDomain),
 					resource.TestCheckResourceAttr(testResourceName, "display_name", updatedName),
@@ -84,10 +86,12 @@ func TestAccResourceNsxtPolicySecurityPolicy_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "rule.0.direction", direction1),
 					resource.TestCheckResourceAttr(testResourceName, "rule.0.ip_version", proto1),
 					resource.TestCheckResourceAttr(testResourceName, "rule.0.action", defaultAction),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.log_label", tag1),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.tag.#", "1"),
 				),
 			},
 			{
-				Config: testAccNsxtPolicySecurityPolicyWithRule(updatedName, direction2, proto2),
+				Config: testAccNsxtPolicySecurityPolicyWithRule(updatedName, direction2, proto2, tag2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicySecurityPolicyExists(testResourceName, defaultDomain),
 					resource.TestCheckResourceAttr(testResourceName, "display_name", updatedName),
@@ -105,6 +109,8 @@ func TestAccResourceNsxtPolicySecurityPolicy_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "rule.0.direction", direction2),
 					resource.TestCheckResourceAttr(testResourceName, "rule.0.ip_version", proto2),
 					resource.TestCheckResourceAttr(testResourceName, "rule.0.action", defaultAction),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.log_label", tag2),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.tag.#", "1"),
 				),
 			},
 		},
@@ -281,7 +287,7 @@ resource "nsxt_policy_security_policy" "test" {
 }`, name, comments)
 }
 
-func testAccNsxtPolicySecurityPolicyWithRule(name string, direction string, protocol string) string {
+func testAccNsxtPolicySecurityPolicyWithRule(name string, direction string, protocol string, ruleTag string) string {
 	return fmt.Sprintf(`
 resource "nsxt_policy_security_policy" "test" {
   display_name    = "%s"
@@ -301,8 +307,14 @@ resource "nsxt_policy_security_policy" "test" {
     display_name = "%s"
     direction    = "%s"
     ip_version   = "%s"
+    log_label    = "%s"
+
+    tag {
+      scope = "color"
+      tag   = "blue"
+    }
   }
-}`, name, name, direction, protocol)
+}`, name, name, direction, protocol, ruleTag)
 }
 
 func testAccNsxtPolicySecurityPolicyDeps() string {

--- a/website/docs/r/policy_gateway_policy.html.markdown
+++ b/website/docs/r/policy_gateway_policy.html.markdown
@@ -68,6 +68,7 @@ The following arguments are supported:
   * `services` - (Optional) List of services to match.
   * `source_groups` - (Optional) A list of source group paths to use for the policy.
   * `source_excluded` - (Optional) A boolean value indicating negation of source groups.
+  * `log_label` - (Optional) Additional information (string) which will be propagated to the rule syslog.
   * `tag` - (Optional) A list of scope + tag pairs to associate with this Rule.
   * `action` - (Optional) The action for the Rule. Must be one of: `ALLOW`, `DROP` or `REJECT`. Defaults to `ALLOW`.
 

--- a/website/docs/r/policy_security_policy.html.markdown
+++ b/website/docs/r/policy_security_policy.html.markdown
@@ -75,7 +75,8 @@ The following arguments are supported:
   * `profiles` - (Optional) Set of profile paths relevant for this rule.
   * `scope` - (Optional) Set of policy object paths where the rule is applied.
   * `services` - (Optional) Set of service paths to match.
-  * `tag` - (Optional) A list of scope + tag pairs to associate with this rule.
+  * `log_label` - (Optional) Additional information (string) which will be propagated to the rule syslog.
+  * `tag` - (Optional) A list of scope + tag pairs to associate with this Rule.
 
 
 ## Attributes Reference


### PR DESCRIPTION
The optional argument "Tag" under rule as part of the nsxt_policy_security_policy resource does not configure the Tag on the rules.
In Policy the Tag of a rule is a string not a scope:tag like on other objects as ultimatelty this is a field propagated to the Syslog.