### PR TITLE
Expose network_name in segment realization data

### DIFF
--- a/nsxt/data_source_nsxt_policy_segment_realization.go
+++ b/nsxt/data_source_nsxt_policy_segment_realization.go
@@ -61,7 +61,6 @@ func dataSourceNsxtPolicySegmentRealizationRead(d *schema.ResourceData, m interf
 		model.SegmentConfigurationState_STATE_IN_SYNC,
 		model.SegmentConfigurationState_STATE_UNKNOWN}
 	targetStates := []string{model.SegmentConfigurationState_STATE_SUCCESS,
-		model.SegmentConfigurationState_STATE_PARTIAL_SUCCESS,
 		model.SegmentConfigurationState_STATE_FAILED,
 		model.SegmentConfigurationState_STATE_ERROR,
 		model.SegmentConfigurationState_STATE_ORPHANED}

--- a/nsxt/data_source_nsxt_policy_segment_realization_test.go
+++ b/nsxt/data_source_nsxt_policy_segment_realization_test.go
@@ -20,6 +20,7 @@ func testAccDataSourceNsxtPolicySegmentRealization(t *testing.T, vlan bool) {
 				Config: testAccNsxtPolicySegmentRealizationTemplate(vlan),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(testResourceName, "state", "success"),
+					resource.TestCheckResourceAttr(testResourceName, "network_name", "terra-test"),
 					resource.TestCheckResourceAttrSet(testResourceName, "path"),
 				),
 			},

--- a/website/docs/d/policy_segment_realization.html.markdown
+++ b/website/docs/d/policy_segment_realization.html.markdown
@@ -20,8 +20,14 @@ resource "nsxt_policy_segment" "s1" {
   transport_zone_path = data.nsxt_transport_zone.tz1.path
 }
 
-data "nsxt_policy_segment_realization" "info" {
+data "nsxt_policy_segment_realization" "s1" {
   path = data.nsxt_policy_segment.s1.path
+}
+
+# usage in vsphere provider
+data "vsphere_network" "net" {
+  name          = nsxt_policy_segment_realization.s1.network_name
+  datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 ```
 

--- a/website/docs/d/policy_segment_realization.html.markdown
+++ b/website/docs/d/policy_segment_realization.html.markdown
@@ -34,3 +34,4 @@ data "nsxt_policy_segment_realization" "info" {
 In addition to arguments listed above, the following attributes are exported:
 
 * `state` - The realization state of the resource: `success`, `partial_success`, `orphaned`, `failed` or `error`.
+* `network_name` - Network name on the hypervisor. This attribute can be used in vsphere provider in order to ensure implicit dependency on segment realization.


### PR DESCRIPTION
This should make it more intuitive for users to define vsphere
network based on this attribute, in which case implicit dependency
will be created. With the dependency in place, vm resource will
wait until network is realized.