### PR TITLE
Provider aliasing support

### DIFF
--- a/nsxt/data_source_nsxt_policy_edge_cluster.go
+++ b/nsxt/data_source_nsxt_policy_edge_cluster.go
@@ -34,7 +34,7 @@ func dataSourceNsxtPolicyEdgeClusterRead(d *schema.ResourceData, m interface{}) 
 	var obj model.PolicyEdgeCluster
 	if objID != "" {
 		// Get by id
-		objGet, err := client.Get(defaultSite, policyEnforcementPoint, objID)
+		objGet, err := client.Get(defaultSite, getPolicyEnforcementPoint(m), objID)
 
 		if err != nil {
 			return handleDataSourceReadError(d, "Edge Cluster", objID, err)
@@ -45,7 +45,7 @@ func dataSourceNsxtPolicyEdgeClusterRead(d *schema.ResourceData, m interface{}) 
 	} else {
 		// Get by full name/prefix
 		includeMarkForDeleteObjectsParam := false
-		objList, err := client.List(defaultSite, policyEnforcementPoint, nil, &includeMarkForDeleteObjectsParam, nil, nil, nil, nil)
+		objList, err := client.List(defaultSite, getPolicyEnforcementPoint(m), nil, &includeMarkForDeleteObjectsParam, nil, nil, nil, nil)
 		if err != nil {
 			return handleListError("Edge Cluster", err)
 		}

--- a/nsxt/data_source_nsxt_policy_edge_node.go
+++ b/nsxt/data_source_nsxt_policy_edge_node.go
@@ -47,7 +47,7 @@ func dataSourceNsxtPolicyEdgeNodeRead(d *schema.ResourceData, m interface{}) err
 	var obj model.PolicyEdgeNode
 	if objID != "" {
 		// Get by id
-		objGet, err := client.Get(defaultSite, policyEnforcementPoint, edgeClusterID, objID)
+		objGet, err := client.Get(defaultSite, getPolicyEnforcementPoint(m), edgeClusterID, objID)
 
 		if err != nil {
 			return handleDataSourceReadError(d, "Edge Node", objID, err)
@@ -56,7 +56,7 @@ func dataSourceNsxtPolicyEdgeNodeRead(d *schema.ResourceData, m interface{}) err
 	} else {
 		// Get by full name/prefix
 		includeMarkForDeleteObjectsParam := false
-		objList, err := client.List(defaultSite, policyEnforcementPoint, edgeClusterID, nil, &includeMarkForDeleteObjectsParam, nil, nil, nil, nil)
+		objList, err := client.List(defaultSite, getPolicyEnforcementPoint(m), edgeClusterID, nil, &includeMarkForDeleteObjectsParam, nil, nil, nil, nil)
 		if err != nil {
 			return handleListError("Edge Node", err)
 		}

--- a/nsxt/data_source_nsxt_policy_segment_realization.go
+++ b/nsxt/data_source_nsxt_policy_segment_realization.go
@@ -43,6 +43,7 @@ func dataSourceNsxtPolicySegmentRealization() *schema.Resource {
 func dataSourceNsxtPolicySegmentRealizationRead(d *schema.ResourceData, m interface{}) error {
 	// Read the realization info by the path, and wait till it is valid
 	connector := getPolicyConnector(m)
+	commonProviderConfig := getCommonProviderConfig(m)
 
 	// Get the realization info of this resource
 	path := d.Get("path").(string)
@@ -55,7 +56,7 @@ func dataSourceNsxtPolicySegmentRealizationRead(d *schema.ResourceData, m interf
 
 	// verifying segment realization on hypervisor
 	segmentID := getPolicyIDFromPath(path)
-	enforcementPointPath := getPolicyEnforcementPointPath()
+	enforcementPointPath := getPolicyEnforcementPointPath(m)
 	client := segments.NewDefaultStateClient(connector)
 	pendingStates := []string{model.SegmentConfigurationState_STATE_PENDING,
 		model.SegmentConfigurationState_STATE_IN_PROGRESS,
@@ -65,7 +66,7 @@ func dataSourceNsxtPolicySegmentRealizationRead(d *schema.ResourceData, m interf
 		model.SegmentConfigurationState_STATE_FAILED,
 		model.SegmentConfigurationState_STATE_ERROR,
 		model.SegmentConfigurationState_STATE_ORPHANED}
-	if toleratePartialSuccess {
+	if commonProviderConfig.ToleratePartialSuccess {
 		targetStates = append(targetStates, model.SegmentConfigurationState_STATE_PARTIAL_SUCCESS)
 	}
 	stateConf := &resource.StateChangeConf{

--- a/nsxt/data_source_nsxt_policy_transport_zone.go
+++ b/nsxt/data_source_nsxt_policy_transport_zone.go
@@ -58,7 +58,7 @@ func dataSourceNsxtPolicyTransportZoneRead(d *schema.ResourceData, m interface{}
 	var obj model.PolicyTransportZone
 	if objID != "" {
 		// Get by id
-		objGet, err := client.Get(defaultSite, policyEnforcementPoint, objID)
+		objGet, err := client.Get(defaultSite, getPolicyEnforcementPoint(m), objID)
 
 		if err != nil {
 			return handleDataSourceReadError(d, "TransportZone", objID, err)
@@ -69,7 +69,7 @@ func dataSourceNsxtPolicyTransportZoneRead(d *schema.ResourceData, m interface{}
 	} else {
 		// Get by full name/prefix
 		includeMarkForDeleteObjectsParam := false
-		objList, err := client.List(defaultSite, policyEnforcementPoint, nil, &includeMarkForDeleteObjectsParam, nil, nil, &includeMarkForDeleteObjectsParam, nil)
+		objList, err := client.List(defaultSite, getPolicyEnforcementPoint(m), nil, &includeMarkForDeleteObjectsParam, nil, nil, &includeMarkForDeleteObjectsParam, nil)
 		if err != nil {
 			return handleListError("TransportZone", err)
 		}

--- a/nsxt/data_source_nsxt_policy_vm.go
+++ b/nsxt/data_source_nsxt_policy_vm.go
@@ -49,7 +49,7 @@ func dataSourceNsxtPolicyVMIDRead(d *schema.ResourceData, m interface{}) error {
 	// TODO: test with KVM based VM
 	objID := getNsxtPolicyVMIDFromSchema(d)
 	if objID != "" {
-		vmObj, err := findNsxtPolicyVMByID(connector, objID)
+		vmObj, err := findNsxtPolicyVMByID(connector, objID, m)
 		if err != nil {
 			return fmt.Errorf("Error while reading Virtual Machine %s: %v", objID, err)
 		}
@@ -57,7 +57,7 @@ func dataSourceNsxtPolicyVMIDRead(d *schema.ResourceData, m interface{}) error {
 	} else {
 		displayName := d.Get("display_name").(string)
 
-		perfectMatch, prefixMatch, err := findNsxtPolicyVMByNamePrefix(connector, displayName)
+		perfectMatch, prefixMatch, err := findNsxtPolicyVMByNamePrefix(connector, displayName, m)
 		if err != nil {
 			return err
 		}

--- a/nsxt/policy_utils.go
+++ b/nsxt/policy_utils.go
@@ -213,6 +213,6 @@ func nsxtPolicyWaitForRealizationStateConf(connector *client.RestConnector, d *s
 	return stateConf
 }
 
-func getPolicyEnforcementPointPath() string {
-	return "/infra/sites/default/enforcement-points/" + policyEnforcementPoint
+func getPolicyEnforcementPointPath(m interface{}) string {
+	return "/infra/sites/default/enforcement-points/" + getPolicyEnforcementPoint(m)
 }

--- a/nsxt/resource_nsxt_logical_switch.go
+++ b/nsxt/resource_nsxt_logical_switch.go
@@ -146,7 +146,7 @@ func resourceNsxtLogicalSwitchCreate(d *schema.ResourceData, m interface{}) erro
 	return resourceNsxtLogicalSwitchRead(d, m)
 }
 
-func resourceNsxtLogicalSwitchVerifyRealization(d *schema.ResourceData, nsxClient *api.APIClient, logicalSwitch *manager.LogicalSwitch) error {
+func resourceNsxtLogicalSwitchVerifyRealization(d *schema.ResourceData, nsxClient *api.APIClient, logicalSwitch *manager.LogicalSwitch, toleratePartialSuccess bool) error {
 	// verifying switch realization on hypervisor
 	pendingStates := []string{"in_progress", "pending"}
 	targetStates := []string{"success"}
@@ -216,7 +216,8 @@ func resourceNsxtLogicalSwitchRead(d *schema.ResourceData, m interface{}) error 
 		return fmt.Errorf("Error during LogicalSwitch read: %v", err)
 	}
 
-	err = resourceNsxtLogicalSwitchVerifyRealization(d, nsxClient, &logicalSwitch)
+	toleratePartialSuccess := getCommonProviderConfig(m.(nsxtClients)).ToleratePartialSuccess
+	err = resourceNsxtLogicalSwitchVerifyRealization(d, nsxClient, &logicalSwitch, toleratePartialSuccess)
 
 	if err != nil {
 		return err

--- a/nsxt/resource_nsxt_policy_vm_tags.go
+++ b/nsxt/resource_nsxt_policy_vm_tags.go
@@ -40,7 +40,7 @@ func resourceNsxtPolicyVMTags() *schema.Resource {
 	}
 }
 
-func listAllPolicyVirtualMachines(connector *client.RestConnector) ([]model.VirtualMachine, error) {
+func listAllPolicyVirtualMachines(connector *client.RestConnector, m interface{}) ([]model.VirtualMachine, error) {
 	client := realized_state.NewDefaultVirtualMachinesClient(connector)
 	var results []model.VirtualMachine
 	boolFalse := false
@@ -49,7 +49,7 @@ func listAllPolicyVirtualMachines(connector *client.RestConnector) ([]model.Virt
 
 	for {
 		// NOTE: the search API does not return resource_type of VirtualMachine
-		enforcementPointPath := getPolicyEnforcementPointPath()
+		enforcementPointPath := getPolicyEnforcementPointPath(m)
 		vms, err := client.List(cursor, &enforcementPointPath, &boolFalse, nil, nil, &boolFalse, nil)
 		if err != nil {
 			return results, err
@@ -66,10 +66,10 @@ func listAllPolicyVirtualMachines(connector *client.RestConnector) ([]model.Virt
 	}
 }
 
-func findNsxtPolicyVMByNamePrefix(connector *client.RestConnector, namePrefix string) ([]model.VirtualMachine, []model.VirtualMachine, error) {
+func findNsxtPolicyVMByNamePrefix(connector *client.RestConnector, namePrefix string, m interface{}) ([]model.VirtualMachine, []model.VirtualMachine, error) {
 	var perfectMatch, prefixMatch []model.VirtualMachine
 
-	allVMs, err := listAllPolicyVirtualMachines(connector)
+	allVMs, err := listAllPolicyVirtualMachines(connector, m)
 	if err != nil {
 		log.Printf("[INFO] Error reading Virtual Machines when looking for name: %s", namePrefix)
 		return perfectMatch, prefixMatch, err
@@ -85,10 +85,10 @@ func findNsxtPolicyVMByNamePrefix(connector *client.RestConnector, namePrefix st
 	return perfectMatch, prefixMatch, nil
 }
 
-func findNsxtPolicyVMByID(connector *client.RestConnector, vmID string) (model.VirtualMachine, error) {
+func findNsxtPolicyVMByID(connector *client.RestConnector, vmID string, m interface{}) (model.VirtualMachine, error) {
 	var virtualMachineStruct model.VirtualMachine
 
-	allVMs, err := listAllPolicyVirtualMachines(connector)
+	allVMs, err := listAllPolicyVirtualMachines(connector, m)
 	if err != nil {
 		log.Printf("[INFO] Error reading Virtual Machines when looking for ID: %s", vmID)
 		return virtualMachineStruct, err
@@ -108,14 +108,14 @@ func findNsxtPolicyVMByID(connector *client.RestConnector, vmID string) (model.V
 	return virtualMachineStruct, fmt.Errorf("Could not find Virtual Machine with ID: %s", vmID)
 }
 
-func updateNsxtPolicyVMTags(connector *client.RestConnector, externalID string, tags []model.Tag) error {
+func updateNsxtPolicyVMTags(connector *client.RestConnector, externalID string, tags []model.Tag, m interface{}) error {
 	client := updateClient.NewDefaultVirtualMachinesClient(connector)
 
 	tagUpdate := model.VirtualMachineTagsUpdate{
 		Tags:             tags,
 		VirtualMachineId: &externalID,
 	}
-	return client.Updatetags(policyEnforcementPoint, tagUpdate)
+	return client.Updatetags(getPolicyEnforcementPoint(m), tagUpdate)
 }
 
 func resourceNsxtPolicyVMTagsRead(d *schema.ResourceData, m interface{}) error {
@@ -126,7 +126,7 @@ func resourceNsxtPolicyVMTagsRead(d *schema.ResourceData, m interface{}) error {
 		return fmt.Errorf("Error obtaining Virtual Machine ID")
 	}
 
-	vm, err := findNsxtPolicyVMByID(connector, vmID)
+	vm, err := findNsxtPolicyVMByID(connector, vmID, m)
 	if err != nil {
 		return fmt.Errorf("Error during Virtual Machine retrieval: %v", err)
 	}
@@ -145,7 +145,7 @@ func resourceNsxtPolicyVMTagsCreate(d *schema.ResourceData, m interface{}) error
 	connector := getPolicyConnector(m)
 	instanceID := d.Get("instance_id").(string)
 
-	vm, err := findNsxtPolicyVMByID(connector, instanceID)
+	vm, err := findNsxtPolicyVMByID(connector, instanceID, m)
 	if err != nil {
 		return fmt.Errorf("Error finding Virtual Machine: %v", err)
 	}
@@ -154,7 +154,7 @@ func resourceNsxtPolicyVMTagsCreate(d *schema.ResourceData, m interface{}) error
 	if tags == nil {
 		tags = make([]model.Tag, 0)
 	}
-	err = updateNsxtPolicyVMTags(connector, *vm.ExternalId, tags)
+	err = updateNsxtPolicyVMTags(connector, *vm.ExternalId, tags, m)
 	if err != nil {
 		return handleCreateError("Virtual Machine Tag", *vm.ExternalId, err)
 	}
@@ -172,13 +172,13 @@ func resourceNsxtPolicyVMTagsDelete(d *schema.ResourceData, m interface{}) error
 	connector := getPolicyConnector(m)
 	instanceID := d.Get("instance_id").(string)
 
-	vm, err := findNsxtPolicyVMByID(connector, instanceID)
+	vm, err := findNsxtPolicyVMByID(connector, instanceID, m)
 	if err != nil {
 		return fmt.Errorf("Error finding Virtual Machine: %v", err)
 	}
 
 	tags := make([]model.Tag, 0)
-	err = updateNsxtPolicyVMTags(connector, *vm.ExternalId, tags)
+	err = updateNsxtPolicyVMTags(connector, *vm.ExternalId, tags, m)
 
 	if err != nil {
 		return handleDeleteError("Virtual Machine Tag", *vm.ExternalId, err)

--- a/nsxt/resource_nsxt_policy_vm_tags_test.go
+++ b/nsxt/resource_nsxt_policy_vm_tags_test.go
@@ -85,7 +85,7 @@ func testAccNSXPolicyVMTagsCheckExists(resourceName string) resource.TestCheckFu
 			return fmt.Errorf("NSX Policy VM Tags resource ID not set in resources ")
 		}
 
-		_, err := findNsxtPolicyVMByID(connector, resourceID)
+		_, err := findNsxtPolicyVMByID(connector, resourceID, testAccProvider.Meta())
 		if err != nil {
 			return fmt.Errorf("Failed to find VM %s", resourceID)
 		}
@@ -103,7 +103,7 @@ func testAccNSXPolicyVMTagsCheckDestroy(state *terraform.State) error {
 		}
 
 		resourceID := rs.Primary.Attributes["id"]
-		vm, err := findNsxtPolicyVMByID(connector, resourceID)
+		vm, err := findNsxtPolicyVMByID(connector, resourceID, testAccProvider.Meta())
 		if err != nil {
 			return fmt.Errorf("Failed to find VM %s", resourceID)
 		}

--- a/nsxt/resource_nsxt_vlan_logical_switch.go
+++ b/nsxt/resource_nsxt_vlan_logical_switch.go
@@ -104,7 +104,8 @@ func resourceNsxtVlanLogicalSwitchCreate(d *schema.ResourceData, m interface{}) 
 		return fmt.Errorf("Unexpected status returned during LogicalSwitch create: %v", resp.StatusCode)
 	}
 
-	err = resourceNsxtLogicalSwitchVerifyRealization(d, nsxClient, &logicalSwitch)
+	toleratePartialSuccess := getCommonProviderConfig(m.(nsxtClients)).ToleratePartialSuccess
+	err = resourceNsxtLogicalSwitchVerifyRealization(d, nsxClient, &logicalSwitch, toleratePartialSuccess)
 
 	if err != nil {
 		return err


### PR DESCRIPTION
In order to enable multiple provider instances, we need to make
sure resources do not rely on global variables for provider
settings.