### PR TITLE
Fix policy segment delete error reporting

### DIFF
--- a/nsxt/resource_nsxt_policy_service.go
+++ b/nsxt/resource_nsxt_policy_service.go
@@ -643,7 +643,7 @@ func resourceNsxtPolicyServiceDelete(d *schema.ResourceData, m interface{}) erro
 	client := infra.NewDefaultServicesClient(connector)
 	err := client.Delete(id)
 	if err != nil {
-		err = handleDeleteError("Service", id, err)
+		return handleDeleteError("Service", id, err)
 	}
 
 	return nil

--- a/nsxt/resource_nsxt_policy_tier0_gateway_interface_test.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway_interface_test.go
@@ -22,7 +22,7 @@ func TestAccResourceNsxtPolicyTier0GatewayInterface_service(t *testing.T) {
 	subnet := "1.1.12.2/24"
 	updatedSubnet := "1.2.12.2/24"
 	ipAddress := "1.1.12.2"
-	updatedIpAddress := "1.2.12.2"
+	updatedIPAddress := "1.2.12.2"
 	testResourceName := "nsxt_policy_tier0_gateway_interface.test"
 
 	resource.Test(t, resource.TestCase{
@@ -64,7 +64,7 @@ func TestAccResourceNsxtPolicyTier0GatewayInterface_service(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "subnets.#", "1"),
 					resource.TestCheckResourceAttr(testResourceName, "subnets.0", updatedSubnet),
 					resource.TestCheckResourceAttr(testResourceName, "ip_addresses.#", "1"),
-					resource.TestCheckResourceAttr(testResourceName, "ip_addresses.0", updatedIpAddress),
+					resource.TestCheckResourceAttr(testResourceName, "ip_addresses.0", updatedIPAddress),
 					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
 					resource.TestCheckResourceAttrSet(testResourceName, "segment_path"),
 					resource.TestCheckResourceAttrSet(testResourceName, "gateway_path"),
@@ -105,7 +105,7 @@ func TestAccResourceNsxtPolicyTier0GatewayInterface_external(t *testing.T) {
 	subnet := "1.1.12.2/24"
 	updatedSubnet := "1.2.12.2/24"
 	ipAddress := "1.1.12.2"
-	updatedIpAddress := "1.2.12.2"
+	updatedIPAddress := "1.2.12.2"
 	testResourceName := "nsxt_policy_tier0_gateway_interface.test"
 
 	resource.Test(t, resource.TestCase{
@@ -150,7 +150,7 @@ func TestAccResourceNsxtPolicyTier0GatewayInterface_external(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "subnets.#", "1"),
 					resource.TestCheckResourceAttr(testResourceName, "subnets.0", updatedSubnet),
 					resource.TestCheckResourceAttr(testResourceName, "ip_addresses.#", "1"),
-					resource.TestCheckResourceAttr(testResourceName, "ip_addresses.0", updatedIpAddress),
+					resource.TestCheckResourceAttr(testResourceName, "ip_addresses.0", updatedIPAddress),
 					resource.TestCheckResourceAttr(testResourceName, "enable_pim", "true"),
 					resource.TestCheckResourceAttr(testResourceName, "urpf_mode", "STRICT"),
 					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),


### PR DESCRIPTION
The error used to be swallowed.
In addition, fix few linter errors.