### PR TITLE
Support locale_service clause on GM tier0

### DIFF
--- a/nsxt/policy_common.go
+++ b/nsxt/policy_common.go
@@ -116,6 +116,32 @@ func getPolicyEdgeClusterPathSchema() *schema.Schema {
 	}
 }
 
+func getPolicyLocaleServiceSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:          schema.TypeList,
+		Optional:      true,
+		Description:   "Locale Service for the gateway",
+		ConflictsWith: []string{"edge_cluster_path"},
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"edge_cluster_path": {
+					Type:         schema.TypeString,
+					Description:  "The path of the edge cluster connected to this gateway",
+					Required:     true,
+					ValidateFunc: validatePolicyPath(),
+				},
+				"preferred_edge_paths": {
+					Type:        schema.TypeSet,
+					Description: "Paths of specific edge nodes",
+					Optional:    true,
+					Elem:        getElemPolicyPathSchema(),
+				},
+				"path": getPathSchema(),
+			},
+		},
+	}
+}
+
 func getPolicyGatewayPathSchema() *schema.Schema {
 	return &schema.Schema{
 		Type:         schema.TypeString,

--- a/nsxt/resource_nsxt_policy_tier0_gateway.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway.go
@@ -750,7 +750,7 @@ func initTier0GatewayLocaleServices(d *schema.ResourceData, connector *client.Re
 
 func verifyPolicyTier0GatewayConfig(d *schema.ResourceData, isGlobalManager bool) error {
 	if isGlobalManager {
-		_, isSet := d.GetOkExists("edge_cluster_path")
+		_, isSet := d.GetOk("edge_cluster_path")
 		if isSet {
 			return fmt.Errorf("edge_cluster_path setting is not supported with NSX Global Manager, please use locale_service instead")
 		}
@@ -758,7 +758,7 @@ func verifyPolicyTier0GatewayConfig(d *schema.ResourceData, isGlobalManager bool
 		return nil
 	}
 
-	_, isSet := d.GetOkExists("locale_service")
+	_, isSet := d.GetOk("locale_serviceee")
 	if isSet {
 		return fmt.Errorf("locale_service setting is only supported with NSX Global Manager")
 	}
@@ -766,7 +766,7 @@ func verifyPolicyTier0GatewayConfig(d *schema.ResourceData, isGlobalManager bool
 	return nil
 }
 
-func resourceNsxtPolicyTier0GatewayResourceToInfraStruct(d *schema.ResourceData, connector *client.RestConnector, isCreate bool, isGlobalManager bool, id string) (model.Infra, error) {
+func policyTier0GatewayResourceToInfraStruct(d *schema.ResourceData, connector *client.RestConnector, isGlobalManager bool, id string) (model.Infra, error) {
 	var infraChildren, gwChildren, lsChildren []*data.StructValue
 	var infraStruct model.Infra
 	converter := bindings.NewTypeConverter()
@@ -805,7 +805,8 @@ func resourceNsxtPolicyTier0GatewayResourceToInfraStruct(d *schema.ResourceData,
 		VrfConfig:              vrfConfig,
 	}
 
-	if !isCreate {
+	if len(d.Id()) > 0 {
+		// This is update flow
 		t0Struct.Revision = &revision
 	}
 	if dhcpPath != "" {
@@ -911,7 +912,7 @@ func resourceNsxtPolicyTier0GatewayCreate(d *schema.ResourceData, m interface{})
 		return err
 	}
 
-	obj, err := resourceNsxtPolicyTier0GatewayResourceToInfraStruct(d, connector, true, isGlobalManager, id)
+	obj, err := policyTier0GatewayResourceToInfraStruct(d, connector, isGlobalManager, id)
 	if err != nil {
 		return err
 	}
@@ -1039,7 +1040,7 @@ func resourceNsxtPolicyTier0GatewayUpdate(d *schema.ResourceData, m interface{})
 		return fmt.Errorf("Error obtaining Tier0 ID")
 	}
 
-	obj, err := resourceNsxtPolicyTier0GatewayResourceToInfraStruct(d, connector, false, isGlobalManager, id)
+	obj, err := policyTier0GatewayResourceToInfraStruct(d, connector, isGlobalManager, id)
 	if err != nil {
 		return err
 	}

--- a/nsxt/resource_nsxt_policy_tier0_gateway_interface.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway_interface.go
@@ -111,7 +111,7 @@ func resourceNsxtPolicyTier0GatewayInterfaceCreate(d *schema.ResourceData, m int
 		return fmt.Errorf("segment_path is mandatory for interface of type %s", ifType)
 	}
 
-	localeService, err := resourceNsxtPolicyTier0GatewayGetLocaleServiceEntry(tier0ID, connector)
+	localeService, err := getPolicyTier0GatewayLocaleServiceWithEdgeCluster(tier0ID, connector)
 	if err != nil {
 		return err
 	}

--- a/website/docs/r/policy_tier0_gateway.html.markdown
+++ b/website/docs/r/policy_tier0_gateway.html.markdown
@@ -56,6 +56,30 @@ resource "nsxt_policy_tier0_gateway" "tier0_gw" {
 }
 ```
 
+## Global manager example usage
+```hcl
+resource "nsxt_policy_tier0_gateway" "tier0_gw" {
+  description   = "Tier-0 provisioned by Terraform"
+  display_name  = "Tier0-gw1"
+  failover_mode = "PREEMPTIVE"
+
+  locale-service {
+    edge_cluster_path = data.nsxt_policy_edge_cluster.paris.path
+  }
+
+  locale-service {
+    edge_cluster_path = data.nsxt_policy_edge_cluster.london.path
+    preferred_edge_paths = [data.nsxt_policy_egde_node.edge1.path]
+  }
+
+  tag {
+    scope = "color"
+    tag   = "blue"
+  }
+}
+```
+
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -64,7 +88,10 @@ The following arguments are supported:
 * `description` - (Optional) Description of the resource.
 * `tag` - (Optional) A list of scope + tag pairs to associate with this Tier-0 gateway.
 * `nsx_id` - (Optional) The NSX ID of this resource. If set, this ID will be used to create the policy resource.
-* `edge_cluster_path` - (Optional) The path of the edge cluster where the Tier-0 is placed. Must be specified when `bgp_config` is enabled.
+* `edge_cluster_path` - (Optional) The path of the edge cluster where the Tier-0 is placed. Must be specified when `bgp_config` is enabled. This argument is not applicable for NSX Global Manager - use locale-services clause instead.
+* `locale_services` - (Optional) This argument is applicable for NSX Global Manager only. Multiple locale services can be specified for multiple locations.
+  * `edge_cluster_path` - (Required) The path of the edge cluster where the Tier-0 is placed.
+  * `preferred_edge_nodes` - (Optional) Policy paths to edge nodes. Specified edge is used as preferred edge cluster member when failover mode is set to `PREEMPTIVE`.
 * `failover_mode` - (Optional) This failover mode determines, whether the preferred service router instance for given logical router will preempt the peer. Accepted values are PREEMPTIVE/NON_PREEMPTIVE.
 * `default_rule_logging` - (Optional) Boolean flag indicating if the default rule logging will be enabled or not. The default value is false.
 * `enable_firewall` - (Optional) Boolean flag indicating if the edge firewall will be enabled or not. The default value is true.


### PR DESCRIPTION
Support multiple instances of locale services on tier0 resource
for global manager.
Tests will be added later, when edge cluster and edge node data
sources are supported on global manager.