### PR TITLE
Switch to H-API in policy T1 Gateway

### DIFF
--- a/nsxt/resource_nsxt_policy_tier1_gateway_interface.go
+++ b/nsxt/resource_nsxt_policy_tier1_gateway_interface.go
@@ -72,7 +72,7 @@ func resourceNsxtPolicyTier1GatewayInterfaceCreate(d *schema.ResourceData, m int
 	id := d.Get("nsx_id").(string)
 	tier1Path := d.Get("gateway_path").(string)
 	tier1ID := getPolicyIDFromPath(tier1Path)
-	localeService, err := resourceNsxtPolicyTier1GatewayGetLocaleServiceEntry(tier1ID, connector)
+	localeService, err := getPolicyTier1GatewayLocaleServiceEntry(tier1ID, connector)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
It would be easier to introduce global manager support with H-API
since only one API call needs to be handled. H-API is more efficient
even regardless GM support.
In addition, fix revision check parameter in T0 Update.