### PR TITLE
Refactor LB service test to fix destroy issue

### DIFF
--- a/nsxt/resource_nsxt_policy_tier0_gateway.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway.go
@@ -990,6 +990,7 @@ func resourceNsxtPolicyTier0GatewayDelete(d *schema.ResourceData, m interface{})
 	if err != nil {
 		return handleDeleteError("Tier0", id, err)
 	}
+	log.Printf("[DEBUG] Success deleting Tier0 with ID %s", id)
 
 	return nil
 

--- a/nsxt/resource_nsxt_policy_tier1_gateway.go
+++ b/nsxt/resource_nsxt_policy_tier1_gateway.go
@@ -657,6 +657,7 @@ func resourceNsxtPolicyTier1GatewayDelete(d *schema.ResourceData, m interface{})
 	if err != nil {
 		return err
 	}
+	log.Printf("[DEBUG] Success deleting Tier1 with ID %s", id)
 
 	return nil
 }


### PR DESCRIPTION
Terraform test does not respect gateway dependency on destroy.
To work around this problem, detach the gateways before destroying.
In addition, add printout on gateway delete to ease debugging (delete
using H-API seems to be slow)