### PR TITLE
Adjust global manager tests to testing topology

### DIFF
--- a/nsxt/data_source_nsxt_policy_edge_cluster_test.go
+++ b/nsxt/data_source_nsxt_policy_edge_cluster_test.go
@@ -23,7 +23,7 @@ func TestAccDataSourceNsxtPolicyEdgeCluster_basic(t *testing.T) {
 			{
 				Config: testAccNsxtPolicyEdgeClusterReadTemplate(edgeClusterName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(testResourceName, "display_name", edgeClusterName),
+					resource.TestCheckResourceAttrSet(testResourceName, "display_name"),
 					resource.TestCheckResourceAttrSet(testResourceName, "path"),
 				),
 			},
@@ -36,7 +36,7 @@ func TestAccDataSourceNsxtPolicyEdgeCluster_basic(t *testing.T) {
 
 func testAccNsxtPolicyEdgeClusterReadTemplate(name string) string {
 	if testAccIsGlobalManager() {
-		return testAccNsxtGlobalPolicyEdgeClusterReadTemplate(name)
+		return testAccNsxtGlobalPolicyEdgeClusterReadTemplate()
 	}
 	return fmt.Sprintf(`
 data "nsxt_policy_edge_cluster" "test" {
@@ -44,16 +44,15 @@ data "nsxt_policy_edge_cluster" "test" {
 }`, name)
 }
 
-func testAccNsxtGlobalPolicyEdgeClusterReadTemplate(name string) string {
+func testAccNsxtGlobalPolicyEdgeClusterReadTemplate() string {
 	return fmt.Sprintf(`
 data "nsxt_policy_site" "test" {
   display_name = "%s"
 }
 
 data "nsxt_policy_edge_cluster" "test" {
-  display_name = "%s"
   site_path = data.nsxt_policy_site.test.path
-}`, getTestSiteName(), name)
+}`, getTestSiteName())
 }
 
 func testAccNsxtPolicyNoEdgeClusterTemplate() string {

--- a/nsxt/data_source_nsxt_policy_tier1_gateway_test.go
+++ b/nsxt/data_source_nsxt_policy_tier1_gateway_test.go
@@ -17,7 +17,7 @@ func TestAccDataSourceNsxtPolicyTier1Gateway_basic(t *testing.T) {
 	testResourceName := "data.nsxt_policy_tier1_gateway.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccDataSourceNsxtPolicyTier1GatewayDeleteByName(routerName)

--- a/nsxt/resource_nsxt_policy_group_test.go
+++ b/nsxt/resource_nsxt_policy_group_test.go
@@ -579,9 +579,10 @@ data "nsxt_policy_site" "test" {
   display_name = "%s"
 }
 data "nsxt_policy_transport_zone" "test"{
-  display_name = "%s"
-  site_path = data.nsxt_policy_site.test.path
-}`, getTestSiteName(), getOverlayTransportZoneName())
+  site_path      = data.nsxt_policy_site.test.path
+  transport_type = "OVERLAY_STANDARD"
+  is_default     = true
+}`, getTestSiteName())
 }
 
 func testNsxtPolicyGroupPathsTransportZone() string {

--- a/nsxt/resource_nsxt_policy_segment_test.go
+++ b/nsxt/resource_nsxt_policy_segment_test.go
@@ -281,7 +281,7 @@ func testAccNsxtPolicySegmentCheckDestroy(state *terraform.State, displayName st
 }
 
 func testAccNsxtPolicySegmentDeps(tzName string) string {
-	return testAccNSXPolicyTransportZoneReadTemplate(tzName) + fmt.Sprintf(`
+	return testAccNSXPolicyTransportZoneReadTemplate(tzName, false) + fmt.Sprintf(`
 
 resource "nsxt_policy_tier1_gateway" "tier1ForSegments" {
   display_name              = "t1gw"

--- a/nsxt/resource_nsxt_policy_vlan_segment_test.go
+++ b/nsxt/resource_nsxt_policy_vlan_segment_test.go
@@ -224,7 +224,7 @@ func testAccNsxtPolicyVlanSegmentCheckDestroy(state *terraform.State, displayNam
 }
 
 func testAccNsxtPolicyVlanSegmentDeps() string {
-	return testAccNSXPolicyTransportZoneReadTemplate(getVlanTransportZoneName())
+	return testAccNSXPolicyTransportZoneReadTemplate(getVlanTransportZoneName(), true)
 }
 
 func testAccNsxtPolicyVlanSegmentImportTemplate(name string) string {

--- a/nsxt/utils_test.go
+++ b/nsxt/utils_test.go
@@ -389,20 +389,19 @@ func testAccNsxtPolicyGatewayWithEdgeClusterTemplate(edgeClusterName string, tie
 	if testAccIsGlobalManager() {
 		return fmt.Sprintf(`
 resource "nsxt_policy_tier%s_gateway" "t%stest" {
-  display_name              = "terraform-t%s-gw"
-  description               = "Acceptance Test"
+  display_name = "terraform-t%s-gw"
+  description  = "Acceptance Test"
   locale_service {
     edge_cluster_path = data.nsxt_policy_edge_cluster.%s.path
   }
   %s
 }`, tier, tier, tier, edgeClusterName, haMode)
-	} else {
-		return fmt.Sprintf(`
+	}
+	return fmt.Sprintf(`
 resource "nsxt_policy_tier%s_gateway" "t%stest" {
-  display_name              = "terraform-t%s-gw"
-  description               = "Acceptance Test"
-  edge_cluster_path         = data.nsxt_policy_edge_cluster.%s.path
+  display_name      = "terraform-t%s-gw"
+  description       = "Acceptance Test"
+  edge_cluster_path = data.nsxt_policy_edge_cluster.%s.path
   %s
 }`, tier, tier, tier, edgeClusterName, haMode)
-	}
 }


### PR DESCRIPTION
In addition, fix transport zone data source to respect is_default
attribute for global manager environment.