### PR TITLE
Paralellize some of resource tests

### DIFF
--- a/nsxt/resource_nsxt_algorithm_type_ns_service_test.go
+++ b/nsxt/resource_nsxt_algorithm_type_ns_service_test.go
@@ -18,7 +18,7 @@ func TestAccResourceNsxtAlgorithmTypeNsService_basic(t *testing.T) {
 	destPort := "21"
 	updatedDestPort := "21"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
@@ -56,7 +56,7 @@ func TestAccResourceNsxtAlgorithmTypeNsService_basic(t *testing.T) {
 func TestAccResourceNsxtAlgorithmTypeNsService_importBasic(t *testing.T) {
 	serviceName := fmt.Sprintf("test-nsx-alg-service")
 	testResourceName := "nsxt_algorithm_type_ns_service.test"
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {

--- a/nsxt/resource_nsxt_ether_type_ns_service_test.go
+++ b/nsxt/resource_nsxt_ether_type_ns_service_test.go
@@ -16,7 +16,7 @@ func TestAccResourceNsxtEtherTypeNsService_basic(t *testing.T) {
 	updateServiceName := fmt.Sprintf("%s-update", serviceName)
 	testResourceName := "nsxt_ether_type_ns_service.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
@@ -51,7 +51,7 @@ func TestAccResourceNsxtEtherTypeNsService_importBasic(t *testing.T) {
 	serviceName := fmt.Sprintf("test-nsx-ether-service")
 	testResourceName := "nsxt_ether_type_ns_service.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {

--- a/nsxt/resource_nsxt_icmp_type_ns_service_test.go
+++ b/nsxt/resource_nsxt_icmp_type_ns_service_test.go
@@ -16,7 +16,7 @@ func TestAccResourceNsxtIcmpTypeNsService_basic(t *testing.T) {
 	updateServiceName := fmt.Sprintf("%s-update", serviceName)
 	testResourceName := "nsxt_icmp_type_ns_service.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
@@ -55,7 +55,7 @@ func TestAccResourceNsxtIcmpTypeNsService_importBasic(t *testing.T) {
 	serviceName := fmt.Sprintf("test-nsx-icmp-service")
 	testResourceName := "nsxt_icmp_type_ns_service.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {

--- a/nsxt/resource_nsxt_igmp_type_ns_service_test.go
+++ b/nsxt/resource_nsxt_igmp_type_ns_service_test.go
@@ -16,7 +16,7 @@ func TestAccResourceNsxtIgmpTypeNsService_basic(t *testing.T) {
 	updateServiceName := fmt.Sprintf("%s-update", serviceName)
 	testResourceName := "nsxt_igmp_type_ns_service.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
@@ -49,7 +49,7 @@ func TestAccResourceNsxtIgmpTypeNsService_importBasic(t *testing.T) {
 	serviceName := fmt.Sprintf("test-nsx-igmp-service")
 	testResourceName := "nsxt_igmp_type_ns_service.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {

--- a/nsxt/resource_nsxt_ip_protocol_ns_service_test.go
+++ b/nsxt/resource_nsxt_ip_protocol_ns_service_test.go
@@ -16,7 +16,7 @@ func TestAccResourceNsxtIpProtocolNsService_basic(t *testing.T) {
 	updateServiceName := fmt.Sprintf("%s-update", serviceName)
 	testResourceName := "nsxt_ip_protocol_ns_service.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
@@ -51,7 +51,7 @@ func TestAccResourceNsxtIpProtocolNsService_importBasic(t *testing.T) {
 	serviceName := fmt.Sprintf("test-nsx-ip-protocol-service")
 	testResourceName := "nsxt_ip_protocol_ns_service.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {

--- a/nsxt/resource_nsxt_ip_set_test.go
+++ b/nsxt/resource_nsxt_ip_set_test.go
@@ -16,7 +16,7 @@ func TestAccResourceNsxtIpSet_basic(t *testing.T) {
 	updateName := fmt.Sprintf("%s-update", name)
 	testResourceName := "nsxt_ip_set.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
@@ -51,7 +51,7 @@ func TestAccResourceNsxtIpSet_noName(t *testing.T) {
 	name := ""
 	testResourceName := "nsxt_ip_set.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
@@ -86,7 +86,7 @@ func TestAccResourceNsxtIpSet_importBasic(t *testing.T) {
 	name := fmt.Sprintf("test-nsx-ip-set")
 	testResourceName := "nsxt_ip_set.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {

--- a/nsxt/resource_nsxt_l4_port_set_ns_service_test.go
+++ b/nsxt/resource_nsxt_l4_port_set_ns_service_test.go
@@ -16,7 +16,7 @@ func TestAccResourceNsxtL4PortNsService_basic(t *testing.T) {
 	updateServiceName := fmt.Sprintf("%s-update", serviceName)
 	testResourceName := "nsxt_l4_port_set_ns_service.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
@@ -51,7 +51,7 @@ func TestAccResourceNsxtL4PortNsService_importBasic(t *testing.T) {
 	serviceName := fmt.Sprintf("test-nsx-l4-service")
 	testResourceName := "nsxt_l4_port_set_ns_service.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {

--- a/nsxt/resource_nsxt_lb_http_forwarding_rule_test.go
+++ b/nsxt/resource_nsxt_lb_http_forwarding_rule_test.go
@@ -19,7 +19,7 @@ func TestAccResourceNsxtLbHttpForwardingRule_basic(t *testing.T) {
 	matchType := "STARTS_WITH"
 	updatedMatchType := "ENDS_WITH"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
@@ -145,7 +145,7 @@ func TestAccResourceNsxtLbHttpForwardingRule_basic(t *testing.T) {
 func TestAccResourceNsxtLbHttpForwardingRule_importBasic(t *testing.T) {
 	name := "test"
 	resourceName := "nsxt_lb_http_forwarding_rule.test"
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {

--- a/nsxt/resource_nsxt_lb_http_request_rewrite_rule_test.go
+++ b/nsxt/resource_nsxt_lb_http_request_rewrite_rule_test.go
@@ -19,7 +19,7 @@ func TestAccResourceNsxtLbHttpRequestRewriteRule_basic(t *testing.T) {
 	matchType := "STARTS_WITH"
 	updatedMatchType := "ENDS_WITH"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
@@ -173,7 +173,7 @@ func testLbRuleConditionAttr(resourceName string, conditionType string, setHash 
 func TestAccResourceNsxtLbHttpRequestRewriteRule_importBasic(t *testing.T) {
 	name := "test"
 	resourceName := "nsxt_lb_http_request_rewrite_rule.test"
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {

--- a/nsxt/resource_nsxt_lb_http_response_rewrite_rule_test.go
+++ b/nsxt/resource_nsxt_lb_http_response_rewrite_rule_test.go
@@ -19,7 +19,7 @@ func TestAccResourceNsxtLbHttpResponseRewriteRule_basic(t *testing.T) {
 	matchType := "CONTAINS"
 	updatedMatchType := "REGEX"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
@@ -139,7 +139,7 @@ func TestAccResourceNsxtLbHttpResponseRewriteRule_basic(t *testing.T) {
 func TestAccResourceNsxtLbHttpResponseRewriteRule_importBasic(t *testing.T) {
 	name := "test"
 	resourceName := "nsxt_lb_http_response_rewrite_rule.test"
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {

--- a/nsxt/resource_nsxt_logical_switch_test.go
+++ b/nsxt/resource_nsxt_logical_switch_test.go
@@ -21,7 +21,7 @@ func TestAccResourceNsxtLogicalSwitch_basic(t *testing.T) {
 	replicationMode := "MTEP"
 	transportZoneName := getOverlayTransportZoneName()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
@@ -74,7 +74,7 @@ func TestAccResourceNsxtLogicalSwitch_vlan(t *testing.T) {
 	updatedvlan := "2"
 	replicationMode := ""
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
@@ -115,7 +115,7 @@ func TestAccResourceNsxtLogicalSwitch_withProfiles(t *testing.T) {
 	customProfileName := "terraform_test_LS_profile"
 	profileType := "SwitchSecuritySwitchingProfile"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
@@ -170,7 +170,7 @@ func TestAccResourceNsxtLogicalSwitch_withMacPool(t *testing.T) {
 	novlan := "0"
 	replicationMode := "MTEP"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
@@ -205,7 +205,7 @@ func TestAccResourceNsxtLogicalSwitch_importBasic(t *testing.T) {
 	replicationMode := "MTEP"
 	transportZoneName := getOverlayTransportZoneName()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {

--- a/nsxt/resource_nsxt_ns_group_test.go
+++ b/nsxt/resource_nsxt_ns_group_test.go
@@ -16,7 +16,7 @@ func TestAccResourceNsxtNSGroup_basic(t *testing.T) {
 	updateGrpName := fmt.Sprintf("%s-update", grpName)
 	testResourceName := "nsxt_ns_group.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
@@ -52,7 +52,7 @@ func TestAccResourceNsxtNSGroup_nested(t *testing.T) {
 	updateGrpName := fmt.Sprintf("%s-update", grpName)
 	testResourceName := "nsxt_ns_group.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
@@ -87,7 +87,7 @@ func TestAccResourceNsxtNSGroup_withCriteria(t *testing.T) {
 	testResourceName := "nsxt_ns_group.test"
 	transportZoneName := getOverlayTransportZoneName()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
@@ -122,7 +122,7 @@ func TestAccResourceNsxtNSGroup_importBasic(t *testing.T) {
 	grpName := fmt.Sprintf("test-nsx-ns-group")
 	testResourceName := "nsxt_ns_group.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
@@ -145,7 +145,7 @@ func TestAccResourceNsxtNSGroup_importWithCriteria(t *testing.T) {
 	grpName := fmt.Sprintf("test-nsx-ns-group")
 	testResourceName := "nsxt_ns_group.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {

--- a/nsxt/resource_nsxt_policy_tier1_gateway_test.go
+++ b/nsxt/resource_nsxt_policy_tier1_gateway_test.go
@@ -245,17 +245,6 @@ func TestAccResourceNsxtPolicyTier1Gateway_withEdgeCluster(t *testing.T) {
 					resource.TestCheckResourceAttr(realizationResourceName, "state", "REALIZED"),
 				),
 			},
-			{
-				Config: testAccNsxtPolicyTier1CreateWithEcRemovedTemplate(updateName, edgeClusterName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccNsxtPolicyTier1Exists(testResourceName),
-					resource.TestCheckResourceAttr(testResourceName, "display_name", updateName),
-					resource.TestCheckResourceAttr(testResourceName, "description", "Acceptance Test"),
-					resource.TestCheckResourceAttr(testResourceName, "edge_cluster_path", ""),
-					resource.TestCheckResourceAttr(testResourceName, "tier0_path", ""),
-					resource.TestCheckResourceAttr(realizationResourceName, "state", "REALIZED"),
-				),
-			},
 		},
 	})
 }
@@ -664,32 +653,6 @@ resource "nsxt_policy_tier1_gateway" "test" {
   display_name      = "%s"
   description       = "Acceptance Test"
   edge_cluster_path = data.nsxt_policy_edge_cluster.EC.path
-
-  tag {
-    scope = "scope1"
-    tag   = "tag1"
-  }
-
-  tag {
-    scope = "scope2"
-    tag   = "tag2"
-  }
-}
-
-data "nsxt_policy_realization_info" "realization_info" {
-  path = nsxt_policy_tier1_gateway.test.path
-}`, edgeClusterName, name)
-}
-
-func testAccNsxtPolicyTier1CreateWithEcRemovedTemplate(name string, edgeClusterName string) string {
-	return fmt.Sprintf(`
-data "nsxt_policy_edge_cluster" "EC" {
-  display_name = "%s"
-}
-
-resource "nsxt_policy_tier1_gateway" "test" {
-  display_name      = "%s"
-  description       = "Acceptance Test"
 
   tag {
     scope = "scope1"

--- a/nsxt/resource_nsxt_vlan_logical_switch_test.go
+++ b/nsxt/resource_nsxt_vlan_logical_switch_test.go
@@ -21,7 +21,7 @@ func TestAccResourceNsxtVlanLogicalSwitch_basic(t *testing.T) {
 	origvlan := "1"
 	updatedvlan := "2"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
@@ -62,7 +62,7 @@ func TestAccResourceNsxtVlanLogicalSwitch_withProfiles(t *testing.T) {
 	customProfileName := "terraform_test_LS_profile"
 	profileType := "SwitchSecuritySwitchingProfile"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
@@ -116,7 +116,7 @@ func TestAccResourceNsxtVlanLogicalSwitch_withMacPool(t *testing.T) {
 	macPoolName := getMacPoolName()
 	novlan := "0"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
@@ -149,7 +149,7 @@ func TestAccResourceNsxtVlanLogicalSwitch_importBasic(t *testing.T) {
 	vlan := "5"
 	transportZoneName := getVlanTransportZoneName()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {


### PR DESCRIPTION
In addition, remove a test that validates removal of edge cluster
from policy gateway. With edge cluster marked as computed, terraform will not detect edge cluster change to null, and thus edge cluster will not be removed unless another diff is detected.