### PR TITLE
Fix error handling in Global Manager section

### DIFF
--- a/nsxt/data_source_nsxt_policy_gateway_qos_profile_test.go
+++ b/nsxt/data_source_nsxt_policy_gateway_qos_profile_test.go
@@ -62,9 +62,9 @@ func testAccDataSourceNsxtPolicyGatewayQosProfileCreate(name string) error {
 	id := newUUID()
 
 	if testAccIsGlobalManager() {
-		gmObj, err := convertModelBindingType(obj, model.GatewayQosProfileBindingType(), gm_model.GatewayQosProfileBindingType())
-		if err != nil {
-			return err
+		gmObj, convErr := convertModelBindingType(obj, model.GatewayQosProfileBindingType(), gm_model.GatewayQosProfileBindingType())
+		if convErr != nil {
+			return convErr
 		}
 		client := gm_infra.NewDefaultGatewayQosProfilesClient(connector)
 		err = client.Patch(id, gmObj.(gm_model.GatewayQosProfile))

--- a/nsxt/data_source_nsxt_policy_qos_profile_test.go
+++ b/nsxt/data_source_nsxt_policy_qos_profile_test.go
@@ -62,9 +62,9 @@ func testAccDataSourceNsxtPolicyQosProfileCreate(name string) error {
 	id := newUUID()
 
 	if testAccIsGlobalManager() {
-		gmObj, err := convertModelBindingType(obj, model.QosProfileBindingType(), gm_model.QosProfileBindingType())
-		if err != nil {
-			return err
+		gmObj, convErr := convertModelBindingType(obj, model.QosProfileBindingType(), gm_model.QosProfileBindingType())
+		if convErr != nil {
+			return convErr
 		}
 
 		client := gm_infra.NewDefaultQosProfilesClient(connector)

--- a/nsxt/resource_nsxt_policy_service.go
+++ b/nsxt/resource_nsxt_policy_service.go
@@ -442,9 +442,9 @@ func resourceNsxtPolicyServiceCreate(d *schema.ResourceData, m interface{}) erro
 	log.Printf("[INFO] Creating service with ID %s", id)
 
 	if isPolicyGlobalManager(m) {
-		gmObj, err := convertModelBindingType(obj, model.ServiceBindingType(), gm_model.ServiceBindingType())
-		if err != nil {
-			return err
+		gmObj, convErr := convertModelBindingType(obj, model.ServiceBindingType(), gm_model.ServiceBindingType())
+		if convErr != nil {
+			return convErr
 		}
 		client := gm_infra.NewDefaultServicesClient(connector)
 		err = client.Patch(id, gmObj.(gm_model.Service))
@@ -661,9 +661,9 @@ func resourceNsxtPolicyServiceUpdate(d *schema.ResourceData, m interface{}) erro
 	var err error
 	if isPolicyGlobalManager(m) {
 
-		gmObj, err := convertModelBindingType(obj, model.ServiceBindingType(), gm_model.ServiceBindingType())
-		if err != nil {
-			return err
+		gmObj, convErr := convertModelBindingType(obj, model.ServiceBindingType(), gm_model.ServiceBindingType())
+		if convErr != nil {
+			return convErr
 		}
 		client := gm_infra.NewDefaultServicesClient(connector)
 		_, err = client.Update(id, gmObj.(gm_model.Service))

--- a/nsxt/resource_nsxt_policy_tier0_gateway.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway.go
@@ -837,7 +837,6 @@ func resourceNsxtPolicyTier0GatewayRead(d *schema.ResourceData, m interface{}) e
 	}
 
 	var obj model.Tier0
-	var err error
 	isGlobalManager := isPolicyGlobalManager(m)
 	if isGlobalManager {
 		client := gm_infra.NewDefaultTier0sClient(connector)
@@ -854,12 +853,12 @@ func resourceNsxtPolicyTier0GatewayRead(d *schema.ResourceData, m interface{}) e
 		obj = convertedObj.(model.Tier0)
 
 	} else {
+		var err error
 		client := infra.NewDefaultTier0sClient(connector)
 		obj, err = client.Get(id)
-	}
-
-	if err != nil {
-		return handleReadError(d, "Tier0", id, err)
+		if err != nil {
+			return handleReadError(d, "Tier0", id, err)
+		}
 	}
 
 	d.Set("display_name", obj.DisplayName)

--- a/nsxt/resource_nsxt_policy_tier1_gateway.go
+++ b/nsxt/resource_nsxt_policy_tier1_gateway.go
@@ -498,14 +498,14 @@ func resourceNsxtPolicyTier1GatewayRead(d *schema.ResourceData, m interface{}) e
 	isGlobalManager := isPolicyGlobalManager(m)
 	if isGlobalManager {
 		client := gm_infra.NewDefaultTier1sClient(connector)
-		gmObj, err := client.Get(id)
-		if err != nil {
-			return handleReadError(d, "Tier0", id, err)
+		gmObj, getErr := client.Get(id)
+		if getErr != nil {
+			return handleReadError(d, "Tier0", id, getErr)
 		}
 
-		convertedObj, err := convertModelBindingType(gmObj, model.Tier1BindingType(), model.Tier1BindingType())
-		if err != nil {
-			return err
+		convertedObj, convErr := convertModelBindingType(gmObj, model.Tier1BindingType(), model.Tier1BindingType())
+		if convErr != nil {
+			return convErr
 		}
 		obj = convertedObj.(model.Tier1)
 	} else {

--- a/nsxt/segment_common.go
+++ b/nsxt/segment_common.go
@@ -751,9 +751,9 @@ func nsxtPolicySegmentCreate(d *schema.ResourceData, m interface{}, isVlan bool)
 		return err
 	}
 	if isPolicyGlobalManager(m) {
-		gmObj, err := convertModelBindingType(obj, model.SegmentBindingType(), gm_model.SegmentBindingType())
-		if err != nil {
-			return err
+		gmObj, convErr := convertModelBindingType(obj, model.SegmentBindingType(), gm_model.SegmentBindingType())
+		if convErr != nil {
+			return convErr
 		}
 		client := gm_infra.NewDefaultSegmentsClient(connector)
 		err = client.Patch(id, gmObj.(gm_model.Segment))
@@ -785,9 +785,9 @@ func nsxtPolicySegmentUpdate(d *schema.ResourceData, m interface{}, isVlan bool)
 	}
 
 	if isPolicyGlobalManager(m) {
-		gmObj, err := convertModelBindingType(obj, model.SegmentBindingType(), gm_model.SegmentBindingType())
-		if err != nil {
-			return err
+		gmObj, convErr := convertModelBindingType(obj, model.SegmentBindingType(), gm_model.SegmentBindingType())
+		if convErr != nil {
+			return convErr
 		}
 		client := gm_infra.NewDefaultSegmentsClient(connector)
 		_, err = client.Update(id, gmObj.(gm_model.Segment))


### PR DESCRIPTION
In some blocks error definition was shadowed, which lead to
swallowing backend error.