### PR TITLE
Parallelize more acceptance tests

### DIFF
--- a/nsxt/resource_nsxt_dhcp_relay_service_test.go
+++ b/nsxt/resource_nsxt_dhcp_relay_service_test.go
@@ -16,8 +16,8 @@ func TestAccResourceNsxtDhcpRelayService_basic(t *testing.T) {
 	updatePrfName := fmt.Sprintf("%s-update", prfName)
 	testResourceName := "nsxt_dhcp_relay_service.test"
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXDhcpRelayServiceCheckDestroy(state, prfName)
@@ -49,8 +49,8 @@ func TestAccResourceNsxtDhcpRelayService_importBasic(t *testing.T) {
 	prfName := fmt.Sprintf("test-nsx-dhcp-relay-service")
 	testResourceName := "nsxt_dhcp_relay_service.test"
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXDhcpRelayServiceCheckDestroy(state, prfName)

--- a/nsxt/resource_nsxt_ip_block_test.go
+++ b/nsxt/resource_nsxt_ip_block_test.go
@@ -18,7 +18,7 @@ func TestAccResourceNsxtIpBlock_basic(t *testing.T) {
 	cidr1 := "1.1.1.0/24"
 	cidr2 := "2.2.2.0/24"
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXIpBlockCheckDestroy(state, name)
@@ -64,7 +64,7 @@ func TestAccResourceNsxtIpBlock_importBasic(t *testing.T) {
 	testResourceName := "nsxt_ip_block.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXIpBlockCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_ip_discovery_switching_profile_test.go
+++ b/nsxt/resource_nsxt_ip_discovery_switching_profile_test.go
@@ -16,7 +16,7 @@ func TestAccResourceNsxtIpDiscoverySwitchingProfile_basic(t *testing.T) {
 	updatedName := fmt.Sprintf("%s-update", name)
 	testResourceName := "nsxt_ip_discovery_switching_profile.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
@@ -63,7 +63,7 @@ func TestAccResourceNsxtIpDiscoverySwitchingProfile_basic(t *testing.T) {
 func TestAccResourceNsxtIpDiscoverySwitchingProfile_importBasic(t *testing.T) {
 	name := "test-nsx-application-profile"
 	testResourceName := "nsxt_ip_discovery_switching_profile.test"
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {

--- a/nsxt/resource_nsxt_mac_management_switching_profile_test.go
+++ b/nsxt/resource_nsxt_mac_management_switching_profile_test.go
@@ -18,8 +18,8 @@ func TestAccResourceNsxtMacManagementSwitchingProfile_basic(t *testing.T) {
 	limit := "100"
 	updatedLimit := "101"
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXMacManagementSwitchingProfileCheckDestroy(state, name)
@@ -68,8 +68,8 @@ func TestAccResourceNsxtMacManagementSwitchingProfile_basic(t *testing.T) {
 func TestAccResourceNsxtMacManagementSwitchingProfile_importBasic(t *testing.T) {
 	name := "test-nsx-application-profile"
 	testResourceName := "nsxt_mac_management_switching_profile.test"
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXMacManagementSwitchingProfileCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_ns_service_group_test.go
+++ b/nsxt/resource_nsxt_ns_service_group_test.go
@@ -16,8 +16,8 @@ func TestAccResourceNsxtNsServiceGroup_basic(t *testing.T) {
 	updateServiceName := fmt.Sprintf("%s-update", serviceName)
 	testResourceName := "nsxt_ns_service_group.test"
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXServiceGroupCheckDestroy(state, serviceName)
@@ -51,8 +51,8 @@ func TestAccResourceNsxtNsServiceGroup_importBasic(t *testing.T) {
 	serviceName := fmt.Sprintf("test-nsx-service-group")
 	testResourceName := "nsxt_ns_service_group.test"
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXServiceGroupCheckDestroy(state, serviceName)

--- a/nsxt/resource_nsxt_policy_dhcp_relay_test.go
+++ b/nsxt/resource_nsxt_policy_dhcp_relay_test.go
@@ -27,7 +27,7 @@ var accTestPolicyDhcpRelayConfigUpdateAttributes = map[string]string{
 func TestAccResourceNsxtPolicyDhcpRelayConfig_basic(t *testing.T) {
 	testResourceName := "nsxt_policy_dhcp_relay.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
@@ -81,7 +81,7 @@ func TestAccResourceNsxtPolicyDhcpRelayConfig_importBasic(t *testing.T) {
 	name := "terra-test-import"
 	testResourceName := "nsxt_policy_dhcp_relay.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {

--- a/nsxt/resource_nsxt_policy_dhcp_server_test.go
+++ b/nsxt/resource_nsxt_policy_dhcp_server_test.go
@@ -26,7 +26,7 @@ var accTestPolicyDhcpServerUpdateAttributes = map[string]string{
 func TestAccResourceNsxtPolicyDhcpServer_basic(t *testing.T) {
 	testResourceName := "nsxt_policy_dhcp_server.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t); testAccNSXVersion(t, "3.0.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
@@ -88,7 +88,7 @@ func TestAccResourceNsxtPolicyDhcpServer_importBasic(t *testing.T) {
 	name := "terra-test-import"
 	testResourceName := "nsxt_policy_dhcp_server.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t); testAccNSXVersion(t, "3.0.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {

--- a/nsxt/resource_nsxt_qos_switching_profile_test.go
+++ b/nsxt/resource_nsxt_qos_switching_profile_test.go
@@ -20,8 +20,8 @@ func TestAccResourceNsxtQosSwitchingProfile_basic(t *testing.T) {
 	peak := "700"
 	updatedPeak := "400"
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXQosSwitchingProfileCheckDestroy(state, name)
@@ -83,8 +83,8 @@ func TestAccResourceNsxtQosSwitchingProfile_basic(t *testing.T) {
 func TestAccResourceNsxtQosSwitchingProfile_importBasic(t *testing.T) {
 	name := "test-nsx-application-profile"
 	testResourceName := "nsxt_qos_switching_profile.test"
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXQosSwitchingProfileCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_spoofguard_switching_profile_test.go
+++ b/nsxt/resource_nsxt_spoofguard_switching_profile_test.go
@@ -16,8 +16,8 @@ func TestAccResourceNsxtSpoofGuardSwitchingProfile_basic(t *testing.T) {
 	updatedName := fmt.Sprintf("%s-update", name)
 	testResourceName := "nsxt_spoofguard_switching_profile.test"
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXSpoofguardSwitchingProfileCheckDestroy(state, name)
@@ -57,8 +57,8 @@ func TestAccResourceNsxtSpoofGuardSwitchingProfile_basic(t *testing.T) {
 func TestAccResourceNsxtSpoofGuardSwitchingProfile_importBasic(t *testing.T) {
 	name := "test-nsx-application-profile"
 	testResourceName := "nsxt_spoofguard_switching_profile.test"
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXSpoofguardSwitchingProfileCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_static_route_test.go
+++ b/nsxt/resource_nsxt_static_route_test.go
@@ -27,7 +27,7 @@ func testAccResourceNsxtStaticRoute(t *testing.T, tier string) {
 	edgeClusterName := getEdgeClusterName()
 	transportZoneName := getOverlayTransportZoneName()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
@@ -78,7 +78,7 @@ func testAccResourceNsxtStaticRouteImport(t *testing.T, tier string) {
 	edgeClusterName := getEdgeClusterName()
 	transportZoneName := getOverlayTransportZoneName()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {

--- a/nsxt/resource_nsxt_switch_security_switching_profile_test.go
+++ b/nsxt/resource_nsxt_switch_security_switching_profile_test.go
@@ -18,8 +18,8 @@ func TestAccResourceNsxtSwitchSecuritySwitchingProfile_basic(t *testing.T) {
 	limit := "700"
 	updatedLimit := "400"
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXSwitchSecuritySwitchingProfileCheckDestroy(state, name)
@@ -79,8 +79,8 @@ func TestAccResourceNsxtSwitchSecuritySwitchingProfile_basic(t *testing.T) {
 func TestAccResourceNsxtSwitchSecuritySwitchingProfile_importBasic(t *testing.T) {
 	name := "test-nsx-application-profile"
 	testResourceName := "nsxt_switch_security_switching_profile.test"
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXSwitchSecuritySwitchingProfileCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_vm_tags_test.go
+++ b/nsxt/resource_nsxt_vm_tags_test.go
@@ -17,7 +17,7 @@ func TestAccResourceNsxtVMTags_basic(t *testing.T) {
 	vmID := getTestVMID()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t); testAccEnvDefined(t, "NSXT_TEST_VM_ID") },
+		PreCheck:  func() { testAccPreCheck(t); testAccEnvDefined(t, "NSXT_TEST_VM_ID"); testAccOnlyLocalManager(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXVMTagsCheckDestroy(state)
@@ -51,7 +51,7 @@ func TestAccResourceNsxtVMTags_import_basic(t *testing.T) {
 	vmID := getTestVMID()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t); testAccEnvDefined(t, "NSXT_TEST_VM_ID") },
+		PreCheck:  func() { testAccPreCheck(t); testAccEnvDefined(t, "NSXT_TEST_VM_ID"); testAccOnlyLocalManager(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXVMTagsCheckDestroy(state)


### PR DESCRIPTION
In addition, skip tests that are not supported for global manager
(these tests pass, but we rather not run them to save time)