### PR TITLE
A better way to assign client auth for policy

### DIFF
--- a/nsxt/provider.go
+++ b/nsxt/provider.go
@@ -420,7 +420,9 @@ func getConnectorTLSConfig(insecure bool, clientCertFile string, clientKeyFile s
 			return nil, fmt.Errorf("Failed to load client cert/key pair: %v", err)
 		}
 
-		tlsConfig.Certificates = []tls.Certificate{cert}
+		tlsConfig.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			return &cert, nil
+		}
 	}
 
 	if len(caFile) > 0 {


### PR DESCRIPTION
Some client certificates may not work when assigning client cert via
Certificate field (https://github.com/golang/go/issues/23924).
This commit uses GetClientCertificate instead.