### PR TITLE
Expose T0 gbp config on GM as a resource

### DIFF
--- a/nsxt/gateway_common.go
+++ b/nsxt/gateway_common.go
@@ -269,7 +269,7 @@ func initChildLocaleService(serviceStruct *model.LocaleServices, markForDelete b
 	return dataValue.(*data.StructValue), nil
 }
 
-func initGatewayLocaleServices(d *schema.ResourceData, connector *client.RestConnector) ([]*data.StructValue, error) {
+func initGatewayLocaleServices(d *schema.ResourceData) ([]*data.StructValue, error) {
 	var localeServices []*data.StructValue
 
 	oldServices, newServices := d.GetChange("locale_service")
@@ -314,7 +314,6 @@ func initGatewayLocaleServices(d *schema.ResourceData, connector *client.RestCon
 			// we need revision
 			serviceStruct.Revision = &revision
 		}
-
 		dataValue, err := initChildLocaleService(&serviceStruct, false)
 		if err != nil {
 			return localeServices, err
@@ -513,4 +512,12 @@ func getLocaleServiceRedistributionConfig(serviceStruct *model.LocaleServices) [
 	elem["rule"] = rules
 	redistributionConfigs = append(redistributionConfigs, elem)
 	return redistributionConfigs
+}
+
+func findTier0LocaleServiceForSite(connector *client.RestConnector, gwID string, sitePath string) (string, error) {
+	localeServices, err := listPolicyTier0GatewayLocaleServices(connector, gwID, true)
+	if err != nil {
+		return "", err
+	}
+	return getGlobalPolicyGatewayLocaleServiceIDWithSite(localeServices, sitePath, gwID)
 }

--- a/nsxt/policy_utils.go
+++ b/nsxt/policy_utils.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+	gm_model "github.com/vmware/vsphere-automation-sdk-go/services/nsxt-gm/model"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/realized_state"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 	"strings"
@@ -71,6 +72,22 @@ func getPolicyTagsFromSchema(d *schema.ResourceData) []model.Tag {
 
 func setPolicyTagsInSchema(d *schema.ResourceData, tags []model.Tag) error {
 	return setCustomizedPolicyTagsInSchema(d, tags, "tag")
+}
+
+func getPolicyGlobalManagerTagsFromSchema(d *schema.ResourceData) []gm_model.Tag {
+	tags := d.Get("tag").(*schema.Set).List()
+	var tagList []gm_model.Tag
+	for _, tag := range tags {
+		data := tag.(map[string]interface{})
+		tagScope := data["scope"].(string)
+		tagTag := data["tag"].(string)
+		elem := gm_model.Tag{
+			Scope: &tagScope,
+			Tag:   &tagTag}
+
+		tagList = append(tagList, elem)
+	}
+	return tagList
 }
 
 func getPathListFromMap(data map[string]interface{}, attrName string) []string {

--- a/nsxt/provider.go
+++ b/nsxt/provider.go
@@ -278,6 +278,7 @@ func Provider() terraform.ResourceProvider {
 			"nsxt_policy_lb_virtual_server":                resourceNsxtPolicyLBVirtualServer(),
 			"nsxt_policy_ip_address_allocation":            resourceNsxtPolicyIPAddressAllocation(),
 			"nsxt_policy_bgp_neighbor":                     resourceNsxtPolicyBgpNeighbor(),
+			"nsxt_policy_bgp_config":                       resourceNsxtPolicyBgpConfig(),
 			"nsxt_policy_dhcp_relay":                       resourceNsxtPolicyDhcpRelayConfig(),
 			"nsxt_policy_dhcp_server":                      resourceNsxtPolicyDhcpServer(),
 		},

--- a/nsxt/resource_nsxt_policy_bgp_config.go
+++ b/nsxt/resource_nsxt_policy_bgp_config.go
@@ -1,0 +1,188 @@
+/* Copyright © 2019 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	gm_locale_services "github.com/vmware/vsphere-automation-sdk-go/services/nsxt-gm/global_infra/tier_0s/locale_services"
+	gm_model "github.com/vmware/vsphere-automation-sdk-go/services/nsxt-gm/model"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+)
+
+// Note: this resource is supported for global manager only
+// TODO: consider supporting it for local manager and deprecating bgp config on T0 gateway
+func resourceNsxtPolicyBgpConfig() *schema.Resource {
+	bgpSchema := getPolicyBGPConfigSchema()
+	bgpSchema["gateway_path"] = getPolicyPathSchema(true, true, "Gateway for this BGP config")
+	bgpSchema["site_path"] = getPolicyPathSchema(true, true, "Site Path for this BGP config")
+
+	return &schema.Resource{
+		Create: resourceNsxtPolicyBgpConfigCreate,
+		Read:   resourceNsxtPolicyBgpConfigRead,
+		Update: resourceNsxtPolicyBgpConfigUpdate,
+		Delete: resourceNsxtPolicyBgpConfigDelete,
+
+		Schema: bgpSchema,
+	}
+}
+
+func resourceNsxtPolicyBgpConfigRead(d *schema.ResourceData, m interface{}) error {
+	if !isPolicyGlobalManager(m) {
+		return globalManagerOnlyError()
+	}
+	connector := getPolicyConnector(m)
+
+	gwPath := d.Get("gateway_path").(string)
+	gwID := getPolicyIDFromPath(gwPath)
+	sitePath := d.Get("site_path").(string)
+	if !isPolicyGlobalManager(m) {
+		return fmt.Errorf("This resource is not supported for local manager")
+	}
+
+	serviceID, err := findTier0LocaleServiceForSite(connector, gwID, sitePath)
+	if err != nil {
+		return err
+	}
+	client := gm_locale_services.NewDefaultBgpClient(connector)
+	gmObj, err := client.Get(gwID, serviceID)
+	if err != nil {
+		return handleReadError(d, "BGP Config", serviceID, err)
+	}
+	lmObj, convErr := convertModelBindingType(gmObj, gm_model.BgpRoutingConfigBindingType(), model.BgpRoutingConfigBindingType())
+	if convErr != nil {
+		return convErr
+	}
+	lmRoutingConfig := lmObj.(model.BgpRoutingConfig)
+
+	data := initPolicyTier0BGPConfigMap(&lmRoutingConfig)
+
+	for key, value := range data {
+		d.Set(key, value)
+	}
+
+	return nil
+}
+
+func resourceNsxtPolicyBgpConfigToStruct(d *schema.ResourceData) (*gm_model.BgpRoutingConfig, error) {
+	ecmp := d.Get("ecmp").(bool)
+	enabled := d.Get("enabled").(bool)
+	interSrIbgp := d.Get("inter_sr_ibgp").(bool)
+	localAsNum := d.Get("local_as_num").(string)
+	multipathRelax := d.Get("multipath_relax").(bool)
+	restartMode := d.Get("graceful_restart_mode").(string)
+	restartTimer := int64(d.Get("graceful_restart_timer").(int))
+	staleTimer := int64(d.Get("graceful_restart_stale_route_timer").(int))
+	tags := getPolicyGlobalManagerTagsFromSchema(d)
+
+	var aggregationStructs []gm_model.RouteAggregationEntry
+	routeAggregations := d.Get("route_aggregation").([]interface{})
+	if len(routeAggregations) > 0 {
+		for _, agg := range routeAggregations {
+			data := agg.(map[string]interface{})
+			prefix := data["prefix"].(string)
+			summary := data["summary_only"].(bool)
+			elem := gm_model.RouteAggregationEntry{
+				Prefix:      &prefix,
+				SummaryOnly: &summary,
+			}
+
+			aggregationStructs = append(aggregationStructs, elem)
+		}
+	}
+
+	restartTimerStruct := gm_model.BgpGracefulRestartTimer{
+		RestartTimer:    &restartTimer,
+		StaleRouteTimer: &staleTimer,
+	}
+
+	restartConfigStruct := gm_model.BgpGracefulRestartConfig{
+		Mode:  &restartMode,
+		Timer: &restartTimerStruct,
+	}
+
+	routeStruct := gm_model.BgpRoutingConfig{
+		Ecmp:                  &ecmp,
+		Enabled:               &enabled,
+		RouteAggregations:     aggregationStructs,
+		Tags:                  tags,
+		InterSrIbgp:           &interSrIbgp,
+		LocalAsNum:            &localAsNum,
+		MultipathRelax:        &multipathRelax,
+		GracefulRestartConfig: &restartConfigStruct,
+	}
+
+	return &routeStruct, nil
+}
+
+func resourceNsxtPolicyBgpConfigCreate(d *schema.ResourceData, m interface{}) error {
+	if !isPolicyGlobalManager(m) {
+		return globalManagerOnlyError()
+	}
+	// This is not a create operation on NSX, since BGP config us auto created
+	connector := getPolicyConnector(m)
+
+	gwPath := d.Get("gateway_path").(string)
+	gwID := getPolicyIDFromPath(gwPath)
+	sitePath := d.Get("site_path").(string)
+
+	obj, err := resourceNsxtPolicyBgpConfigToStruct(d)
+	if err != nil {
+		return handleCreateError("BgpRoutingConfig", gwID, err)
+	}
+
+	serviceID, err := findTier0LocaleServiceForSite(connector, gwID, sitePath)
+	if err != nil {
+		return handleCreateError("BgpRoutingConfig", gwID, err)
+	}
+
+	client := gm_locale_services.NewDefaultBgpClient(connector)
+	err = client.Patch(gwID, serviceID, *obj)
+	if err != nil {
+		return handleCreateError("BgpRoutingConfig", gwID, err)
+	}
+	d.SetId("bgp")
+
+	return resourceNsxtPolicyBgpConfigRead(d, m)
+}
+
+func resourceNsxtPolicyBgpConfigUpdate(d *schema.ResourceData, m interface{}) error {
+	connector := getPolicyConnector(m)
+
+	gwPath := d.Get("gateway_path").(string)
+	gwID := getPolicyIDFromPath(gwPath)
+	sitePath := d.Get("site_path").(string)
+	revision := int64(d.Get("revision").(int))
+
+	obj, err := resourceNsxtPolicyBgpConfigToStruct(d)
+	if err != nil {
+		return handleUpdateError("BgpRoutingConfig", gwID, err)
+	}
+
+	serviceID, err := findTier0LocaleServiceForSite(connector, gwID, sitePath)
+	if err != nil {
+		return handleUpdateError("BgpRoutingConfig", gwID, err)
+	}
+
+	obj.Revision = &revision
+
+	client := gm_locale_services.NewDefaultBgpClient(connector)
+	_, err = client.Update(gwID, serviceID, *obj)
+	if err != nil {
+		return handleUpdateError("BgpRoutingConfig", gwID, err)
+	}
+
+	return resourceNsxtPolicyBgpConfigRead(d, m)
+}
+
+func resourceNsxtPolicyBgpConfigDelete(d *schema.ResourceData, m interface{}) error {
+	// BGP object can not be deleted as long as locale service exist
+	// Delete call on NSX should revert settings to default, but this is
+	// not supported on platform as of today
+	// In order to revert manually, NSX requires us to disable BGP first
+	// It makes more sense to avoid any action here (which mimics the computed
+	// bgp behavior on T0 for local manager)
+
+	return nil
+}

--- a/nsxt/resource_nsxt_policy_bgp_config_test.go
+++ b/nsxt/resource_nsxt_policy_bgp_config_test.go
@@ -1,0 +1,167 @@
+/* Copyright © 2019 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"testing"
+)
+
+var accTestPolicyBgpConfigCreateAttributes = map[string]string{
+	"enabled":                            "false",
+	"inter_sr_ibgp":                      "false",
+	"local_as_num":                       "12000012",
+	"multipath_relax":                    "true",
+	"prefix":                             "20.0.1.0/24",
+	"summary_only":                       "true",
+	"graceful_restart_mode":              "HELPER_ONLY",
+	"graceful_restart_timer":             "2000",
+	"graceful_restart_stale_route_timer": "2100",
+}
+
+var accTestPolicyBgpConfigUpdateAttributes = map[string]string{
+	"enabled":                            "true",
+	"inter_sr_ibgp":                      "true",
+	"local_as_num":                       "12000013",
+	"multipath_relax":                    "false",
+	"prefix":                             "20.0.2.0/24",
+	"summary_only":                       "false",
+	"graceful_restart_mode":              "DISABLE",
+	"graceful_restart_timer":             "3000",
+	"graceful_restart_stale_route_timer": "3100",
+}
+
+func TestAccResourceNsxtPolicyBgpConfig_basic(t *testing.T) {
+	testResourceName := "nsxt_policy_bgp_config.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccOnlyGlobalManager(t); testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyBgpConfigTemplate(true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(testResourceName, "enabled", accTestPolicyBgpConfigCreateAttributes["enabled"]),
+					resource.TestCheckResourceAttr(testResourceName, "inter_sr_ibgp", accTestPolicyBgpConfigCreateAttributes["inter_sr_ibgp"]),
+					resource.TestCheckResourceAttr(testResourceName, "local_as_num", accTestPolicyBgpConfigCreateAttributes["local_as_num"]),
+					resource.TestCheckResourceAttr(testResourceName, "multipath_relax", accTestPolicyBgpConfigCreateAttributes["multipath_relax"]),
+					resource.TestCheckResourceAttr(testResourceName, "route_aggregation.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "route_aggregation.0.prefix", accTestPolicyBgpConfigCreateAttributes["prefix"]),
+					resource.TestCheckResourceAttr(testResourceName, "route_aggregation.0.summary_only", accTestPolicyBgpConfigCreateAttributes["summary_only"]),
+					resource.TestCheckResourceAttr(testResourceName, "graceful_restart_mode", accTestPolicyBgpConfigCreateAttributes["graceful_restart_mode"]),
+					resource.TestCheckResourceAttr(testResourceName, "graceful_restart_timer", accTestPolicyBgpConfigCreateAttributes["graceful_restart_timer"]),
+					resource.TestCheckResourceAttr(testResourceName, "graceful_restart_stale_route_timer", accTestPolicyBgpConfigCreateAttributes["graceful_restart_stale_route_timer"]),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
+				),
+			},
+			{
+				Config: testAccNsxtPolicyBgpConfigTemplate(false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(testResourceName, "enabled", accTestPolicyBgpConfigUpdateAttributes["enabled"]),
+					resource.TestCheckResourceAttr(testResourceName, "inter_sr_ibgp", accTestPolicyBgpConfigUpdateAttributes["inter_sr_ibgp"]),
+					resource.TestCheckResourceAttr(testResourceName, "local_as_num", accTestPolicyBgpConfigUpdateAttributes["local_as_num"]),
+					resource.TestCheckResourceAttr(testResourceName, "multipath_relax", accTestPolicyBgpConfigUpdateAttributes["multipath_relax"]),
+					resource.TestCheckResourceAttr(testResourceName, "route_aggregation.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "route_aggregation.0.prefix", accTestPolicyBgpConfigUpdateAttributes["prefix"]),
+					resource.TestCheckResourceAttr(testResourceName, "route_aggregation.0.summary_only", accTestPolicyBgpConfigUpdateAttributes["summary_only"]),
+					resource.TestCheckResourceAttr(testResourceName, "graceful_restart_mode", accTestPolicyBgpConfigUpdateAttributes["graceful_restart_mode"]),
+					resource.TestCheckResourceAttr(testResourceName, "graceful_restart_timer", accTestPolicyBgpConfigUpdateAttributes["graceful_restart_timer"]),
+					resource.TestCheckResourceAttr(testResourceName, "graceful_restart_stale_route_timer", accTestPolicyBgpConfigUpdateAttributes["graceful_restart_stale_route_timer"]),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtPolicyBgpConfig_minimalistic(t *testing.T) {
+	testResourceName := "nsxt_policy_bgp_config.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccOnlyGlobalManager(t); testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyBgpConfigMinimalistic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccNsxtPolicyBgpConfigTemplate(createFlow bool) string {
+	var attrMap map[string]string
+	if createFlow {
+		attrMap = accTestPolicyBgpConfigCreateAttributes
+	} else {
+		attrMap = accTestPolicyBgpConfigUpdateAttributes
+	}
+	return testAccNsxtPolicyGMGatewayDeps() + fmt.Sprintf(`
+
+resource "nsxt_policy_tier0_gateway" "test" {
+  display_name = "terraform-bgp-test"
+  locale_service {
+    edge_cluster_path = data.nsxt_policy_edge_cluster.ec_site1.path
+  }
+}
+
+resource "nsxt_policy_bgp_config" "test" {
+  enabled         = %s
+  inter_sr_ibgp   = %s
+  local_as_num    = "%s"
+  multipath_relax = %s
+
+  route_aggregation {
+    prefix       = "%s"
+    summary_only = "%s"
+  }
+
+  graceful_restart_mode              = "%s"
+  graceful_restart_timer             = %s
+  graceful_restart_stale_route_timer = %s
+
+  gateway_path = nsxt_policy_tier0_gateway.test.path
+  site_path    = data.nsxt_policy_site.site1.path
+  tag {
+    scope = "scope1"
+    tag   = "tag1"
+  }
+}
+
+
+data "nsxt_policy_realization_info" "bgp_realization_info" {
+  path      = nsxt_policy_bgp_config.test.path
+  site_path = data.nsxt_policy_site.site1.path
+}`, attrMap["enabled"], attrMap["inter_sr_ibgp"], attrMap["local_as_num"], attrMap["multipath_relax"], attrMap["prefix"], attrMap["summary_only"], attrMap["graceful_restart_mode"], attrMap["graceful_restart_timer"], attrMap["graceful_restart_stale_route_timer"])
+}
+
+func testAccNsxtPolicyBgpConfigMinimalistic() string {
+	return testAccNsxtPolicyGMGatewayDeps() + fmt.Sprintf(`
+
+resource "nsxt_policy_tier0_gateway" "test" {
+  display_name = "terraform-bgp-test"
+  locale_service {
+    edge_cluster_path = data.nsxt_policy_edge_cluster.ec_site1.path
+  }
+}
+
+resource "nsxt_policy_bgp_config" "test" {
+  gateway_path    = nsxt_policy_tier0_gateway.test.path
+  site_path       = data.nsxt_policy_site.site1.path
+}
+
+data "nsxt_policy_realization_info" "realization_info" {
+  path      = nsxt_policy_bgp_config.test.path
+  site_path = data.nsxt_policy_site.site1.path
+}`)
+}

--- a/nsxt/resource_nsxt_policy_tier0_gateway.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway.go
@@ -110,7 +110,7 @@ func resourceNsxtPolicyTier0Gateway() *schema.Resource {
 			"ipv6_dad_profile_path":  getIPv6DadPathSchema(),
 			"edge_cluster_path":      getPolicyEdgeClusterPathSchema(),
 			"locale_service":         getPolicyLocaleServiceSchema(false),
-			"bgp_config":             getPolicyBGPConfigSchema(),
+			"bgp_config":             getPolicyTier0BGPConfigSchema(),
 			"vrf_config":             getPolicyVRFConfigSchema(),
 			"dhcp_config_path":       getPolicyPathSchema(false, false, "Policy path to DHCP server or relay configuration to use for this Tier0"),
 			"intersite_config":       getGatewayIntersiteConfigSchema(),
@@ -119,7 +119,7 @@ func resourceNsxtPolicyTier0Gateway() *schema.Resource {
 	}
 }
 
-func getPolicyBGPConfigSchema() *schema.Schema {
+func getPolicyTier0BGPConfigSchema() *schema.Schema {
 	return &schema.Schema{
 		// NOTE: setting bpg_config requires a edge_cluster_path
 		Type:        schema.TypeList,
@@ -128,88 +128,91 @@ func getPolicyBGPConfigSchema() *schema.Schema {
 		Computed:    true,
 		MaxItems:    1,
 		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{
-				"tag":      getTagsSchema(),
-				"revision": getRevisionSchema(),
-				"path":     getPathSchema(),
-				"ecmp": {
-					Type:        schema.TypeBool,
-					Description: "Flag to enable ECMP",
-					Optional:    true,
-					Default:     true,
-				},
-				"enabled": {
-					Type:        schema.TypeBool,
-					Description: "Flag to enable BGP configuration",
-					Optional:    true,
-					Default:     true,
-				},
-				"inter_sr_ibgp": {
-					Type:        schema.TypeBool,
-					Description: "Enable inter SR IBGP configuration",
-					Optional:    true,
-					Default:     true,
-				},
-				"local_as_num": {
-					Type: schema.TypeString,
-					Description: "	BGP AS number in ASPLAIN/ASDOT Format",
-					Optional:     true,
-					Default:      policyBGPLocalAsNumDefault, //NOTE: empty string disables
-					ValidateFunc: validate4ByteASNPlain,
-				},
-				"multipath_relax": {
-					Type:        schema.TypeBool,
-					Description: "Flag to enable BGP multipath relax option",
-					Optional:    true,
-					Default:     true,
-				},
-				"route_aggregation": {
-					Type:        schema.TypeList,
-					Description: "List of routes to be aggregated",
-					Optional:    true,
-					MaxItems:    1000,
-					Elem: &schema.Resource{
-						Schema: map[string]*schema.Schema{
-							"prefix": {
-								Type:         schema.TypeString,
-								Description:  "CIDR of aggregate address",
-								Optional:     true,
-								ValidateFunc: validateCidr(),
-							},
-							"summary_only": {
-								Type:        schema.TypeBool,
-								Description: "Send only summarized route",
-								Optional:    true,
-								Default:     true,
-							},
-						},
+			Schema: getPolicyBGPConfigSchema(),
+		},
+	}
+}
+func getPolicyBGPConfigSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"tag":      getTagsSchema(),
+		"revision": getRevisionSchema(),
+		"path":     getPathSchema(),
+		"ecmp": {
+			Type:        schema.TypeBool,
+			Description: "Flag to enable ECMP",
+			Optional:    true,
+			Default:     true,
+		},
+		"enabled": {
+			Type:        schema.TypeBool,
+			Description: "Flag to enable BGP configuration",
+			Optional:    true,
+			Default:     true,
+		},
+		"inter_sr_ibgp": {
+			Type:        schema.TypeBool,
+			Description: "Enable inter SR IBGP configuration",
+			Optional:    true,
+			Default:     true,
+		},
+		"local_as_num": {
+			Type: schema.TypeString,
+			Description: "	BGP AS number in ASPLAIN/ASDOT Format",
+			Optional:     true,
+			Default:      policyBGPLocalAsNumDefault, //NOTE: empty string disables
+			ValidateFunc: validate4ByteASNPlain,
+		},
+		"multipath_relax": {
+			Type:        schema.TypeBool,
+			Description: "Flag to enable BGP multipath relax option",
+			Optional:    true,
+			Default:     true,
+		},
+		"route_aggregation": {
+			Type:        schema.TypeList,
+			Description: "List of routes to be aggregated",
+			Optional:    true,
+			MaxItems:    1000,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"prefix": {
+						Type:         schema.TypeString,
+						Description:  "CIDR of aggregate address",
+						Optional:     true,
+						ValidateFunc: validateCidr(),
+					},
+					"summary_only": {
+						Type:        schema.TypeBool,
+						Description: "Send only summarized route",
+						Optional:    true,
+						Default:     true,
 					},
 				},
-				"graceful_restart_mode": {
-					// BgpGracefulRestartConfig.mode
-					Type:         schema.TypeString,
-					Description:  "BGP Graceful Restart Configuration Mode",
-					ValidateFunc: validation.StringInSlice(nsxtPolicyTier0GatewayBgpGracefulRestartModes, false),
-					Optional:     true,
-					Default:      model.BgpGracefulRestartConfig_MODE_HELPER_ONLY,
-				},
-				"graceful_restart_timer": {
-					// BgpGracefulRestartConfig.timer.restart_timer
-					Type:         schema.TypeInt,
-					Description:  "BGP Graceful Restart Timer",
-					Optional:     true,
-					Default:      policyBGPGracefulRestartTimerDefault,
-					ValidateFunc: validation.IntBetween(1, 3600),
-				},
-				"graceful_restart_stale_route_timer": {
-					// BgpGracefulRestartConfig.timer.stale_route_timer
-					Type:         schema.TypeInt,
-					Description:  "BGP Stale Route Timer",
-					Optional:     true,
-					Default:      policyBGPGracefulRestartStaleRouteTimerDefault,
-					ValidateFunc: validation.IntBetween(1, 3600),
-				},
 			},
+		},
+		"graceful_restart_mode": {
+			// BgpGracefulRestartConfig.mode
+			Type:         schema.TypeString,
+			Description:  "BGP Graceful Restart Configuration Mode",
+			ValidateFunc: validation.StringInSlice(nsxtPolicyTier0GatewayBgpGracefulRestartModes, false),
+			Optional:     true,
+			Default:      model.BgpGracefulRestartConfig_MODE_HELPER_ONLY,
+		},
+		"graceful_restart_timer": {
+			// BgpGracefulRestartConfig.timer.restart_timer
+			Type:         schema.TypeInt,
+			Description:  "BGP Graceful Restart Timer",
+			Optional:     true,
+			Default:      policyBGPGracefulRestartTimerDefault,
+			ValidateFunc: validation.IntBetween(1, 3600),
+		},
+		"graceful_restart_stale_route_timer": {
+			// BgpGracefulRestartConfig.timer.stale_route_timer
+			Type:         schema.TypeInt,
+			Description:  "BGP Stale Route Timer",
+			Optional:     true,
+			Default:      policyBGPGracefulRestartStaleRouteTimerDefault,
+			ValidateFunc: validation.IntBetween(1, 3600),
 		},
 	}
 }
@@ -346,18 +349,7 @@ func getPolicyTier0GatewayLocaleServiceWithEdgeCluster(gwID string, connector *c
 	return nil, nil
 }
 
-func resourceNsxtPolicyTier0GatewayReadBGPConfig(d *schema.ResourceData, connector *client.RestConnector, localeService model.LocaleServices) error {
-	var bgpConfigs []map[string]interface{}
-	client := locale_services.NewDefaultBgpClient(connector)
-
-	t0Id := d.Id()
-	bgpConfig, err := client.Get(t0Id, *localeService.Id)
-	if err != nil {
-		if isNotFoundError(err) {
-			return d.Set("bgp_config", bgpConfigs)
-		}
-		return err
-	}
+func initPolicyTier0BGPConfigMap(bgpConfig *model.BgpRoutingConfig) map[string]interface{} {
 
 	cfgMap := make(map[string]interface{})
 	cfgMap["revision"] = int(*bgpConfig.Revision)
@@ -399,8 +391,24 @@ func resourceNsxtPolicyTier0GatewayReadBGPConfig(d *schema.ResourceData, connect
 	}
 	cfgMap["route_aggregation"] = aggregationList
 
-	bgpConfigs = append(bgpConfigs, cfgMap)
+	return cfgMap
+}
 
+func resourceNsxtPolicyTier0GatewayReadBGPConfig(d *schema.ResourceData, connector *client.RestConnector, localeService model.LocaleServices) error {
+	var bgpConfigs []map[string]interface{}
+	client := locale_services.NewDefaultBgpClient(connector)
+
+	t0Id := d.Id()
+	bgpConfig, err := client.Get(t0Id, *localeService.Id)
+	if err != nil {
+		if isNotFoundError(err) {
+			return d.Set("bgp_config", bgpConfigs)
+		}
+		return err
+	}
+
+	data := initPolicyTier0BGPConfigMap(&bgpConfig)
+	bgpConfigs = append(bgpConfigs, data)
 	return d.Set("bgp_config", bgpConfigs)
 }
 
@@ -671,6 +679,21 @@ func verifyPolicyTier0GatewayConfig(d *schema.ResourceData, isGlobalManager bool
 	return nil
 }
 
+func initPolicyTier0ChildBgpConfig(config *model.BgpRoutingConfig) (*data.StructValue, error) {
+	converter := bindings.NewTypeConverter()
+	converter.SetMode(bindings.REST)
+	childConfig := model.ChildBgpRoutingConfig{
+		ResourceType:     "ChildBgpRoutingConfig",
+		BgpRoutingConfig: config,
+	}
+	dataValue, errors := converter.ConvertToVapi(childConfig, model.ChildBgpRoutingConfigBindingType())
+	if errors != nil {
+		return nil, fmt.Errorf("Error converting child BGP Routing Configuration: %v", errors[0])
+	}
+
+	return dataValue.(*data.StructValue), nil
+}
+
 func policyTier0GatewayResourceToInfraStruct(d *schema.ResourceData, connector *client.RestConnector, isGlobalManager bool, id string) (model.Infra, error) {
 	var infraChildren, gwChildren, lsChildren []*data.StructValue
 	var infraStruct model.Infra
@@ -728,17 +751,13 @@ func policyTier0GatewayResourceToInfraStruct(d *schema.ResourceData, connector *
 
 	bgpConfig := d.Get("bgp_config").([]interface{})
 	if len(bgpConfig) > 0 && !isGlobalManager {
-		// BGP not supported for global manager yet
+		// For Global Manager BGP is defined as separate resource
 		routingConfigStruct := resourceNsxtPolicyTier0GatewayBGPConfigSchemaToStruct(bgpConfig[0], vrfConfig != nil, id)
-		childConfig := model.ChildBgpRoutingConfig{
-			ResourceType:     "ChildBgpRoutingConfig",
-			BgpRoutingConfig: &routingConfigStruct,
+		structValue, err := initPolicyTier0ChildBgpConfig(&routingConfigStruct)
+		if err != nil {
+			return infraStruct, err
 		}
-		dataValue, errors := converter.ConvertToVapi(childConfig, model.ChildBgpRoutingConfigBindingType())
-		if errors != nil {
-			return infraStruct, fmt.Errorf("Error converting child BGP Routing Configuration: %v", errors[0])
-		}
-		lsChildren = append(lsChildren, dataValue.(*data.StructValue))
+		lsChildren = append(lsChildren, structValue)
 	}
 
 	edgeClusterPath := d.Get("edge_cluster_path").(string)
@@ -765,7 +784,7 @@ func policyTier0GatewayResourceToInfraStruct(d *schema.ResourceData, connector *
 		}
 	} else {
 		// Global Manager
-		localeServices, err := initGatewayLocaleServices(d, connector)
+		localeServices, err := initGatewayLocaleServices(d)
 		if err != nil {
 			return infraStruct, err
 		}
@@ -897,6 +916,7 @@ func resourceNsxtPolicyTier0GatewayRead(d *schema.ResourceData, m interface{}) e
 				cfgMap["revision"] = service.Revision
 				redistributionConfigs := getLocaleServiceRedistributionConfig(&service)
 				cfgMap["redistribution_config"] = redistributionConfigs
+
 				services = append(services, cfgMap)
 
 			} else {

--- a/nsxt/resource_nsxt_policy_tier1_gateway.go
+++ b/nsxt/resource_nsxt_policy_tier1_gateway.go
@@ -427,7 +427,7 @@ func policyTier1GatewayResourceToInfraStruct(d *schema.ResourceData, connector *
 	}
 
 	if isGlobalManager {
-		localeServices, err := initGatewayLocaleServices(d, connector)
+		localeServices, err := initGatewayLocaleServices(d)
 		if err != nil {
 			return infraStruct, err
 		}

--- a/website/docs/r/policy_bgp_config.html.markdown
+++ b/website/docs/r/policy_bgp_config.html.markdown
@@ -1,0 +1,60 @@
+---
+layout: "nsxt"
+page_title: "NSXT: nsxt_policy_bgp_config"
+sidebar_current: "docs-nsxt-resource-policy-bgp-config"
+description: A resource to configure BGP Settings of Tier0 Gateway on NSX Global Manager.
+---
+
+# nsxt_policy_bgp_config
+
+This resource provides a method for the management of BGP for T0 Gateway on specific site. This resource is only supported on NSX Global Manager. A single resource should be specified per T0 Gateway + Site.
+## Example Usage
+
+```hcl
+resource "nsxt_policy_bgp_config" "gw1-paris" {
+  site_path    = data.nsxt_policy_site.paris.path
+  gateway_path = nsxt_policy_tier0_gateway.gw1.path
+
+  enabled                = true
+  inter_sr_ibgp          = true
+  local_as_num           = 60001
+  graceful_restart_mode  = HELPER_ONLY
+  graceful_restart_timer = 2400
+
+  route_aggregation {
+    prefix       = "20.1.0.0/24"
+    summary_only = false
+  }
+}
+```
+
+~> **NOTE:** Since BGP config is auto-created on NSX, this resource will update NSX object, but never create or delete it.
+
+## Argument Reference
+
+The following arguments are supported:
+
+  * `ecmp` - (Optional) A boolean flag to enable/disable ECMP. Default is `true`.
+  * `enabled` - (Optional) A boolean flag to enable/disable BGP. Default is `true`.
+  * `inter_sr_ibgp` - (Optional) A boolean flag to enable/disable inter SR IBGP configuration. Default is `true`.
+  * `local_as_num` - (Optional) BGP AS number in ASPLAIN/ASDOT Format. Default is `65000`.
+  * `multipath_relax` - (Optional) A boolean flag to enable/disable multipath relax for BGP. Default is `true`.
+  * `graceful_restart_mode` - (Optional) Setting to control BGP graceful restart mode, one of `DISABLE`, `GR_AND_HELPER`, `HELPER_ONLY`.
+  * `graceful_restart_timer` - (Optional) BGP graceful restart timer. Default is `180`.
+  * `graceful_restart_stale_route_timer` - (Optional) BGP stale route timer. Default is `600`.
+  * `route_aggregation`- (Optional) Zero or more route aggregations for BGP.
+    * `prefix` - (Required) CIDR of aggregate address.
+    * `summary_only` - (Optional) A boolean flag to enable/disable summarized route info. Default is `true`.
+  * `tag` - (Optional) A list of scope + tag pairs to associate with this Tier-0 gateway's BGP configuration.
+
+## Attributes Reference
+
+In addition to arguments listed above, the following attributes are exported:
+
+* `id` - ID of the resource.
+* `revision` - Indicates current revision number of the object as seen by NSX-T API server. This attribute can be useful for debugging.
+* `path` - The NSX path of the policy resource. This path should be used as `bgp_path` in `nsxt_policy_bgp_neighbor` resource configuration.
+
+## Importing
+
+Since BGP config is autocreated by the backend, and terraform create is de-facto an update, importing the resource is not useful and thus not supported.

--- a/website/docs/r/policy_tier0_gateway.html.markdown
+++ b/website/docs/r/policy_tier0_gateway.html.markdown
@@ -114,7 +114,7 @@ The following arguments are supported:
 * `internal_transit_subnets` - (Optional) Internal transit subnets in CIDR format. At most 1 CIDR.
 * `transit_subnets` - (Optional) Transit subnets in CIDR format.
 * `dhcp_config_path` - (Optional) Policy path to DHCP server or relay configuration to use for this gateway.
-* `bgp_config` - (Optional) The BGP configuration for the Tier-0 gateway. When enabled a valid `edge_cluster_path` must be set on the Tier-0 gateway.
+* `bgp_config` - (Optional) The BGP configuration for the Tier-0 gateway. When enabled a valid `edge_cluster_path` must be set on the Tier-0 gateway. This clause is not applicable for Global Manager - use `nsxt_policy_bgp_config` resource instead.
   * `tag` - (Optional) A list of scope + tag pairs to associate with this Tier-0 gateway's BGP configuration.
   * `ecmp` - (Optional) A boolean flag to enable/disable ECMP. Default is `true`.
   * `enabled` - (Optional) A boolean flag to enable/disable BGP. Default is `true`.

--- a/website/nsxt.erb
+++ b/website/nsxt.erb
@@ -142,9 +142,6 @@
                         <li<%= sidebar_current("docs-nsxt-resource-policy-gateway-policy") %>>
                             <a href="/docs/providers/nsxt/r/policy_gateway_policy.html">nsxt_policy_gateway_policy</a>
                         </li>
-                        <li<%= sidebar_current("docs-nsxt-resource-policy-gateway-prefix-list") %>>
-                            <a href="/docs/providers/nsxt/r/policy_gateway_prefix_list.html">nsxt_policy_gateway_prefix_list</a>
-                        </li>
                         <li<%= sidebar_current("docs-nsxt-resource-policy-static-route") %>>
                             <a href="/docs/providers/nsxt/r/policy_static_route.html">nsxt_policy_static_route</a>
                         </li>
@@ -168,6 +165,9 @@
                         </li>
                         <li<%= sidebar_current("docs-nsxt-resource-policy-bgp-neighbor") %>>
                             <a href="/docs/providers/nsxt/r/policy_bgp_neighbor.html">nsxt_policy_bgp_neighbor</a>
+                        </li>
+                        <li<%= sidebar_current("docs-nsxt-resource-policy-bgp-config") %>>
+                            <a href="/docs/providers/nsxt/r/policy_bgp_config.html">nsxt_policy_bgp_config</a>
                         </li>
                         <li<%= sidebar_current("docs-nsxt-resource-policy-dhcp-relay") %>>
                             <a href="/docs/providers/nsxt/r/policy_dhcp_relay.html">nsxt_policy_dhcp_relay</a>


### PR DESCRIPTION
In order to ease user experience while configuring bgp for Global
Manager, bgp config is exposed here as a separate resource, that
is defined by gateway path and site path.
Since BGP is auto-configured by NSX for each locale service, this
resource will de-facto perform only update operations.
For local manager, BGP config remains part of T0 gateway.