### PR TITLE
Revert "Avoid extra roundtrip for updating GW services" for HA_vip support

### DIFF
--- a/nsxt/resource_nsxt_policy_tier0_gateway.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway.go
@@ -784,7 +784,7 @@ func policyTier0GatewayResourceToInfraStruct(d *schema.ResourceData, connector *
 		}
 	} else {
 		// Global Manager
-		localeServices, err := initGatewayLocaleServices(d)
+		localeServices, err := initGatewayLocaleServices(d, connector, listPolicyTier0GatewayLocaleServices)
 		if err != nil {
 			return infraStruct, err
 		}

--- a/nsxt/resource_nsxt_policy_tier1_gateway.go
+++ b/nsxt/resource_nsxt_policy_tier1_gateway.go
@@ -427,7 +427,7 @@ func policyTier1GatewayResourceToInfraStruct(d *schema.ResourceData, connector *
 	}
 
 	if isGlobalManager {
-		localeServices, err := initGatewayLocaleServices(d)
+		localeServices, err := initGatewayLocaleServices(d, connector, listPolicyTier1GatewayLocaleServices)
 		if err != nil {
 			return infraStruct, err
 		}


### PR DESCRIPTION
This reverts commit d313896e79a1362366e176d1d9eba75a144a5a5e.

HA_vip support will require keeping the tier0 locale-service unchanged for tier0 / interfaces actions.